### PR TITLE
Phase 1: add route registry and basic navigation controller

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.20)
+project(seedsigner_lvgl VERSION 0.1.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+option(SEEDSIGNER_BUILD_EXAMPLES "Build example executables" ON)
+option(SEEDSIGNER_BUILD_TESTS "Build tests" ON)
+option(SEEDSIGNER_ENABLE_LVGL "Fetch and link LVGL" OFF)
+
+add_library(seedsigner_lvgl
+  src/runtime/EventQueue.cpp
+  src/runtime/ScreenRegistry.cpp
+  src/runtime/UiRuntime.cpp
+  src/platform/HeadlessDisplay.cpp
+  src/screens/PlaceholderScreen.cpp
+)
+
+target_include_directories(seedsigner_lvgl
+  PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+target_compile_features(seedsigner_lvgl PUBLIC cxx_std_17)
+
+if(SEEDSIGNER_BUILD_EXAMPLES)
+  add_executable(host_sim_demo examples/host_sim_demo.cpp)
+  target_link_libraries(host_sim_demo PRIVATE seedsigner_lvgl)
+endif()
+
+if(SEEDSIGNER_BUILD_TESTS)
+  include(CTest)
+  enable_testing()
+
+  add_executable(ui_runtime_smoke_test tests/ui_runtime_smoke_test.cpp)
+  target_link_libraries(ui_runtime_smoke_test PRIVATE seedsigner_lvgl)
+
+  add_test(NAME ui_runtime_smoke_test COMMAND ui_runtime_smoke_test)
+endif()

--- a/README.md
+++ b/README.md
@@ -4,14 +4,19 @@ Modern LVGL C++ module inspired by SeedSigner screens and flows, designed to be 
 
 ## Project status
 
-Phase 0 — discovery and architecture.
+Phase 1 has started with a minimal host-simulated runtime skeleton.
 
-No implementation claims yet. The current goal is to:
-- inventory SeedSigner screens, flows, components, and data formats
-- define the C++/LVGL architecture
-- define the external control API
-- define camera frame injection requirements
-- split implementation into reviewable milestones
+Current implementation scope:
+- CMake-based C++/LVGL build bootstrap
+- headless host display integration for smoke validation
+- `UiRuntime` top-level owner with screen registry and outbound event queue scaffolding
+- placeholder screen demo route and smoke test
+
+Still intentionally out of scope:
+- embedded bring-up
+- full navigation stack
+- camera ingestion
+- SeedSigner screen parity
 
 ## Goals
 
@@ -21,21 +26,23 @@ No implementation claims yet. The current goal is to:
 - Be suitable for MicroPython-driven use on ESP32-P4 / ESP32-S3
 - Preserve room for host-side simulation/testing
 
-## Non-goals for Phase 0
+## Non-goals for Phase 1 bootstrap
 
 - full UI parity in one pass
 - direct port of all Python code into C++
 - premature hardware-specific optimizations without architecture justification
+- choosing the long-term desktop simulator frontend before the runtime core exists
 
-## Planned workstreams
+## Build the host skeleton
 
-1. SeedSigner UI inventory
-2. Flow and state model
-3. LVGL component architecture
-4. External control API
-5. Camera integration contract
-6. Memory/performance strategy for ESP32 targets
-7. Incremental implementation roadmap
+```bash
+cmake -S . -B build
+cmake --build build
+ctest --test-dir build --output-on-failure
+./build/host_sim_demo
+```
+
+The initial simulator target is deliberately headless. It uses LVGL with a dummy host display so the runtime, screen lifecycle, and draw/flush path can be exercised in CI and on developer machines without committing yet to SDL or embedded platform glue.
 
 ## Expected deliverables in this repo
 
@@ -43,4 +50,5 @@ No implementation claims yet. The current goal is to:
 - ADRs
 - issue backlog
 - milestones and phased implementation plan
-- later: C++ module, examples, tests, integration code
+- C++ runtime skeleton, examples, and smoke tests
+- later: richer screen implementations, camera integration, bindings, and target-specific platform code

--- a/include/seedsigner_lvgl/contracts/RouteDescriptor.hpp
+++ b/include/seedsigner_lvgl/contracts/RouteDescriptor.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+#include "seedsigner_lvgl/contracts/RouteId.hpp"
+
+namespace seedsigner::lvgl {
+
+using ScreenToken = std::uint32_t;
+using PropertyMap = std::unordered_map<std::string, std::string>;
+
+struct RouteDescriptor {
+    RouteId route_id;
+    PropertyMap args;
+};
+
+struct ActiveRoute {
+    RouteId route_id;
+    ScreenToken screen_token{0};
+    std::size_t stack_depth{0};
+};
+
+}  // namespace seedsigner::lvgl

--- a/include/seedsigner_lvgl/contracts/RouteId.hpp
+++ b/include/seedsigner_lvgl/contracts/RouteId.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+#include <utility>
+
+namespace seedsigner::lvgl {
+
+class RouteId {
+public:
+    RouteId() = default;
+    explicit RouteId(std::string value) : value_(std::move(value)) {}
+
+    const std::string& value() const noexcept { return value_; }
+    bool empty() const noexcept { return value_.empty(); }
+
+    friend bool operator==(const RouteId& lhs, const RouteId& rhs) noexcept {
+        return lhs.value_ == rhs.value_;
+    }
+
+    friend bool operator!=(const RouteId& lhs, const RouteId& rhs) noexcept {
+        return !(lhs == rhs);
+    }
+
+private:
+    std::string value_;
+};
+
+struct RouteIdHash {
+    std::size_t operator()(const RouteId& route_id) const noexcept {
+        return std::hash<std::string>{}(route_id.value());
+    }
+};
+
+}  // namespace seedsigner::lvgl

--- a/include/seedsigner_lvgl/navigation/NavigationController.hpp
+++ b/include/seedsigner_lvgl/navigation/NavigationController.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+
+#include "seedsigner_lvgl/contracts/RouteDescriptor.hpp"
+#include "seedsigner_lvgl/screen/ScreenRegistry.hpp"
+
+namespace seedsigner::lvgl {
+
+class NavigationController {
+public:
+    explicit NavigationController(const ScreenRegistry& registry);
+
+    std::optional<ActiveRoute> activate(const RouteDescriptor& route);
+    std::optional<ActiveRoute> replace(const RouteDescriptor& route);
+    std::optional<ActiveRoute> get_active_route() const noexcept;
+
+private:
+    struct ScreenSlot {
+        ActiveRoute route;
+        std::unique_ptr<Screen> screen;
+    };
+
+    std::optional<ActiveRoute> install(const RouteDescriptor& route);
+    void teardown_active();
+
+    const ScreenRegistry& registry_;
+    std::optional<ScreenSlot> active_screen_;
+    ScreenToken next_screen_token_{1};
+};
+
+}  // namespace seedsigner::lvgl

--- a/include/seedsigner_lvgl/runtime/UiRuntime.hpp
+++ b/include/seedsigner_lvgl/runtime/UiRuntime.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <optional>
+
+#include "seedsigner_lvgl/contracts/RouteDescriptor.hpp"
+#include "seedsigner_lvgl/navigation/NavigationController.hpp"
+#include "seedsigner_lvgl/screen/ScreenRegistry.hpp"
+
+namespace seedsigner::lvgl {
+
+class UiRuntime {
+public:
+    UiRuntime();
+
+    ScreenRegistry& screen_registry() noexcept { return screen_registry_; }
+    const ScreenRegistry& screen_registry() const noexcept { return screen_registry_; }
+
+    std::optional<ActiveRoute> activate(const RouteDescriptor& route);
+    std::optional<ActiveRoute> replace(const RouteDescriptor& route);
+    std::optional<ActiveRoute> get_active_route() const noexcept;
+
+private:
+    ScreenRegistry screen_registry_;
+    NavigationController navigation_controller_;
+};
+
+}  // namespace seedsigner::lvgl

--- a/include/seedsigner_lvgl/screen/Screen.hpp
+++ b/include/seedsigner_lvgl/screen/Screen.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "seedsigner_lvgl/contracts/RouteDescriptor.hpp"
+
+namespace seedsigner::lvgl {
+
+class Screen {
+public:
+    virtual ~Screen() = default;
+
+    virtual void create(const RouteDescriptor& route) = 0;
+    virtual void on_activate() {}
+    virtual void on_deactivate() {}
+    virtual void destroy() {}
+};
+
+}  // namespace seedsigner::lvgl

--- a/include/seedsigner_lvgl/screen/ScreenRegistry.hpp
+++ b/include/seedsigner_lvgl/screen/ScreenRegistry.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+
+#include "seedsigner_lvgl/contracts/RouteId.hpp"
+#include "seedsigner_lvgl/screen/Screen.hpp"
+
+namespace seedsigner::lvgl {
+
+class ScreenRegistry {
+public:
+    using Factory = std::function<std::unique_ptr<Screen>()>;
+
+    bool register_route(RouteId route_id, Factory factory);
+    bool has_route(const RouteId& route_id) const;
+    std::unique_ptr<Screen> create(const RouteId& route_id) const;
+
+private:
+    std::unordered_map<RouteId, Factory, RouteIdHash> factories_;
+};
+
+}  // namespace seedsigner::lvgl

--- a/src/navigation/NavigationController.cpp
+++ b/src/navigation/NavigationController.cpp
@@ -1,0 +1,54 @@
+#include "seedsigner_lvgl/navigation/NavigationController.hpp"
+
+namespace seedsigner::lvgl {
+
+NavigationController::NavigationController(const ScreenRegistry& registry)
+    : registry_(registry) {}
+
+std::optional<ActiveRoute> NavigationController::activate(const RouteDescriptor& route) {
+    return replace(route);
+}
+
+std::optional<ActiveRoute> NavigationController::replace(const RouteDescriptor& route) {
+    auto next_screen = registry_.create(route.route_id);
+    if (!next_screen) {
+        return std::nullopt;
+    }
+
+    teardown_active();
+
+    const ActiveRoute active_route{
+        .route_id = route.route_id,
+        .screen_token = next_screen_token_++,
+        .stack_depth = 1,
+    };
+
+    next_screen->create(route);
+    next_screen->on_activate();
+    active_screen_ = ScreenSlot{.route = active_route, .screen = std::move(next_screen)};
+    return active_route;
+}
+
+std::optional<ActiveRoute> NavigationController::get_active_route() const noexcept {
+    if (!active_screen_) {
+        return std::nullopt;
+    }
+
+    return active_screen_->route;
+}
+
+std::optional<ActiveRoute> NavigationController::install(const RouteDescriptor& route) {
+    return replace(route);
+}
+
+void NavigationController::teardown_active() {
+    if (!active_screen_) {
+        return;
+    }
+
+    active_screen_->screen->on_deactivate();
+    active_screen_->screen->destroy();
+    active_screen_.reset();
+}
+
+}  // namespace seedsigner::lvgl

--- a/src/runtime/UiRuntime.cpp
+++ b/src/runtime/UiRuntime.cpp
@@ -1,0 +1,20 @@
+#include "seedsigner_lvgl/runtime/UiRuntime.hpp"
+
+namespace seedsigner::lvgl {
+
+UiRuntime::UiRuntime()
+    : navigation_controller_(screen_registry_) {}
+
+std::optional<ActiveRoute> UiRuntime::activate(const RouteDescriptor& route) {
+    return navigation_controller_.activate(route);
+}
+
+std::optional<ActiveRoute> UiRuntime::replace(const RouteDescriptor& route) {
+    return navigation_controller_.replace(route);
+}
+
+std::optional<ActiveRoute> UiRuntime::get_active_route() const noexcept {
+    return navigation_controller_.get_active_route();
+}
+
+}  // namespace seedsigner::lvgl

--- a/src/screen/ScreenRegistry.cpp
+++ b/src/screen/ScreenRegistry.cpp
@@ -1,0 +1,26 @@
+#include "seedsigner_lvgl/screen/ScreenRegistry.hpp"
+
+namespace seedsigner::lvgl {
+
+bool ScreenRegistry::register_route(RouteId route_id, Factory factory) {
+    if (route_id.empty() || !factory) {
+        return false;
+    }
+
+    return factories_.emplace(std::move(route_id), std::move(factory)).second;
+}
+
+bool ScreenRegistry::has_route(const RouteId& route_id) const {
+    return factories_.find(route_id) != factories_.end();
+}
+
+std::unique_ptr<Screen> ScreenRegistry::create(const RouteId& route_id) const {
+    const auto it = factories_.find(route_id);
+    if (it == factories_.end()) {
+        return nullptr;
+    }
+
+    return it->second();
+}
+
+}  // namespace seedsigner::lvgl

--- a/tests/navigation_runtime_tests.cpp
+++ b/tests/navigation_runtime_tests.cpp
@@ -1,0 +1,140 @@
+#include <cassert>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "seedsigner_lvgl/runtime/UiRuntime.hpp"
+#include "seedsigner_lvgl/screen/Screen.hpp"
+
+namespace {
+
+struct LifecycleLog {
+    std::vector<std::string> entries;
+};
+
+class RecordingScreen : public seedsigner::lvgl::Screen {
+public:
+    explicit RecordingScreen(LifecycleLog& log) : log_(log) {}
+
+    void create(const seedsigner::lvgl::RouteDescriptor& route) override {
+        log_.entries.push_back("create:" + route.route_id.value());
+        if (const auto it = route.args.find("title"); it != route.args.end()) {
+            log_.entries.push_back("arg:title=" + it->second);
+        }
+    }
+
+    void on_activate() override {
+        log_.entries.push_back("activate");
+    }
+
+    void on_deactivate() override {
+        log_.entries.push_back("deactivate");
+    }
+
+    void destroy() override {
+        log_.entries.push_back("destroy");
+    }
+
+private:
+    LifecycleLog& log_;
+};
+
+void test_registry_and_activation() {
+    LifecycleLog log;
+    seedsigner::lvgl::UiRuntime runtime;
+
+    const bool registered = runtime.screen_registry().register_route(
+        seedsigner::lvgl::RouteId{"main_menu"},
+        [&log]() { return std::make_unique<RecordingScreen>(log); });
+
+    assert(registered);
+    assert(runtime.screen_registry().has_route(seedsigner::lvgl::RouteId{"main_menu"}));
+
+    const auto active = runtime.activate({
+        .route_id = seedsigner::lvgl::RouteId{"main_menu"},
+        .args = {{"title", "Main Menu"}},
+    });
+
+    assert(active.has_value());
+    assert(active->route_id.value() == "main_menu");
+    assert(active->screen_token == 1);
+    assert(runtime.get_active_route()->route_id.value() == "main_menu");
+
+    assert((log.entries == std::vector<std::string>{
+        "create:main_menu",
+        "arg:title=Main Menu",
+        "activate",
+    }));
+}
+
+void test_replace_tears_down_previous_screen() {
+    LifecycleLog first_log;
+    LifecycleLog second_log;
+    seedsigner::lvgl::UiRuntime runtime;
+
+    runtime.screen_registry().register_route(
+        seedsigner::lvgl::RouteId{"main_menu"},
+        [&first_log]() { return std::make_unique<RecordingScreen>(first_log); });
+    runtime.screen_registry().register_route(
+        seedsigner::lvgl::RouteId{"scan_qr"},
+        [&second_log]() { return std::make_unique<RecordingScreen>(second_log); });
+
+    const auto first = runtime.activate({.route_id = seedsigner::lvgl::RouteId{"main_menu"}});
+    const auto second = runtime.replace({.route_id = seedsigner::lvgl::RouteId{"scan_qr"}});
+
+    assert(first.has_value());
+    assert(second.has_value());
+    assert(first->screen_token == 1);
+    assert(second->screen_token == 2);
+    assert(runtime.get_active_route()->route_id.value() == "scan_qr");
+
+    assert((first_log.entries == std::vector<std::string>{
+        "create:main_menu",
+        "activate",
+        "deactivate",
+        "destroy",
+    }));
+    assert((second_log.entries == std::vector<std::string>{
+        "create:scan_qr",
+        "activate",
+    }));
+}
+
+void test_unknown_route_does_not_install_screen() {
+    seedsigner::lvgl::UiRuntime runtime;
+    const auto missing = runtime.activate({.route_id = seedsigner::lvgl::RouteId{"missing"}});
+
+    assert(!missing.has_value());
+    assert(!runtime.get_active_route().has_value());
+}
+
+void test_failed_replace_keeps_existing_screen() {
+    LifecycleLog log;
+    seedsigner::lvgl::UiRuntime runtime;
+
+    runtime.screen_registry().register_route(
+        seedsigner::lvgl::RouteId{"main_menu"},
+        [&log]() { return std::make_unique<RecordingScreen>(log); });
+
+    const auto first = runtime.activate({.route_id = seedsigner::lvgl::RouteId{"main_menu"}});
+    const auto missing = runtime.replace({.route_id = seedsigner::lvgl::RouteId{"missing"}});
+
+    assert(first.has_value());
+    assert(!missing.has_value());
+    assert(runtime.get_active_route()->route_id.value() == "main_menu");
+    assert((log.entries == std::vector<std::string>{
+        "create:main_menu",
+        "activate",
+    }));
+}
+
+}  // namespace
+
+int main() {
+    test_registry_and_activation();
+    test_replace_tears_down_previous_screen();
+    test_unknown_route_does_not_install_screen();
+    test_failed_replace_keeps_existing_screen();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a stable `RouteId` wrapper plus route descriptors/tokens
- add `ScreenRegistry`, `NavigationController`, and `UiRuntime` for activation/replacement
- add host-buildable CMake/test scaffolding for the first navigation slice
- cover route registration, activation, replacement lifecycle, and failed replacement behavior with tests

## Notes
- kept scope narrow on purpose: no modal stack, no history model, no business-flow logic
- issue #6 runtime skeleton was not present on `main`, so this PR adds the minimum buildable/testable scaffold needed to land #13 cleanly
- structure is intended to leave room for the later event queue and first real screens without locking in a giant abstraction stack

Closes #13