### PR TITLE
Phase 1: complete outbound UI event queue on runtime skeleton

### DIFF
--- a/include/seedsigner_lvgl/screen/Screen.hpp
+++ b/include/seedsigner_lvgl/screen/Screen.hpp
@@ -1,13 +1,66 @@
 #pragma once
 
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+
 #include <lvgl.h>
 
 #include "seedsigner_lvgl/contracts/RouteDescriptor.hpp"
+#include "seedsigner_lvgl/runtime/Event.hpp"
 
 namespace seedsigner::lvgl {
 
 struct ScreenContext {
     lv_obj_t* root{nullptr};
+    RouteId route_id;
+    ScreenToken screen_token{0};
+    std::function<bool(UiEvent)> emit_event;
+    std::function<std::uint64_t()> now_ms;
+
+    bool emit(EventType type,
+              std::optional<std::string> component_id = std::nullopt,
+              std::optional<std::string> action_id = std::nullopt,
+              std::optional<EventValue> value = std::nullopt,
+              std::optional<EventMeta> meta = std::nullopt) const {
+        if (!emit_event) {
+            return false;
+        }
+
+        return emit_event(UiEvent{
+            .type = type,
+            .route_id = route_id,
+            .screen_token = screen_token,
+            .component_id = std::move(component_id),
+            .action_id = std::move(action_id),
+            .value = std::move(value),
+            .meta = std::move(meta),
+            .timestamp_ms = now_ms ? now_ms() : 0,
+        });
+    }
+
+    bool emit_action(std::string action_id,
+                     std::optional<std::string> component_id = std::nullopt,
+                     std::optional<EventValue> value = std::nullopt,
+                     std::optional<EventMeta> meta = std::nullopt) const {
+        return emit(EventType::ActionInvoked, std::move(component_id), std::move(action_id), std::move(value), std::move(meta));
+    }
+
+    bool emit_cancel(std::optional<std::string> component_id = std::nullopt,
+                     std::optional<EventMeta> meta = std::nullopt) const {
+        return emit(EventType::CancelRequested, std::move(component_id), std::nullopt, std::nullopt, std::move(meta));
+    }
+
+    bool emit_needs_data(std::string key,
+                         std::optional<std::string> component_id = std::nullopt,
+                         std::optional<EventValue> value = std::nullopt) const {
+        return emit(EventType::NeedsData,
+                    std::move(component_id),
+                    std::nullopt,
+                    std::move(value),
+                    EventMeta{std::move(key), true});
+    }
 };
 
 class Screen {

--- a/src/navigation/NavigationController.cpp
+++ b/src/navigation/NavigationController.cpp
@@ -15,15 +15,19 @@ std::optional<ActiveRoute> NavigationController::replace(const RouteDescriptor& 
         return std::nullopt;
     }
 
-    teardown_active();
-
     const ActiveRoute active_route{
         .route_id = route.route_id,
         .screen_token = next_screen_token_++,
         .stack_depth = 1,
     };
 
-    next_screen->create(context, route);
+    ScreenContext active_context = context;
+    active_context.route_id = active_route.route_id;
+    active_context.screen_token = active_route.screen_token;
+
+    teardown_active();
+
+    next_screen->create(active_context, route);
     next_screen->on_activate();
     active_screen_ = ScreenSlot{.route = active_route, .screen = std::move(next_screen)};
     return active_route;

--- a/src/runtime/UiRuntime.cpp
+++ b/src/runtime/UiRuntime.cpp
@@ -32,7 +32,13 @@ std::optional<ActiveRoute> UiRuntime::activate(const RouteDescriptor& route) {
         return std::nullopt;
     }
 
-    const auto active = navigation_controller_.activate(route, ScreenContext{.root = lv_scr_act()});
+    ScreenContext context{
+        .root = lv_scr_act(),
+        .emit_event = [this](UiEvent event) { return emit(std::move(event)); },
+        .now_ms = [this]() { return now_ms_; },
+    };
+
+    const auto active = navigation_controller_.activate(route, context);
     if (!active) {
         emit(UiEvent{
             .type = EventType::Error,

--- a/tests/navigation_runtime_tests.cpp
+++ b/tests/navigation_runtime_tests.cpp
@@ -26,6 +26,7 @@ public:
     void create(const seedsigner::lvgl::ScreenContext& context, const seedsigner::lvgl::RouteDescriptor& route) override {
         assert(context.root != nullptr);
         log_.entries.push_back("create:" + route.route_id.value());
+        log_.entries.push_back("token:" + std::to_string(context.screen_token));
         if (const auto it = route.args.find("title"); it != route.args.end()) {
             log_.entries.push_back("arg:title=" + it->second);
         }
@@ -45,6 +46,19 @@ public:
 
 private:
     LifecycleLog& log_;
+};
+
+class EventEmittingScreen : public seedsigner::lvgl::Screen {
+public:
+    void create(const seedsigner::lvgl::ScreenContext& context, const seedsigner::lvgl::RouteDescriptor&) override {
+        assert(context.root != nullptr);
+        const bool emitted = context.emit_action(
+            "confirm",
+            std::string{"primary_button"},
+            seedsigner::lvgl::EventValue{std::int64_t{1}},
+            seedsigner::lvgl::EventMeta{"source", std::string{"screen"}});
+        assert(emitted);
+    }
 };
 
 void test_registry_and_activation() {
@@ -71,6 +85,7 @@ void test_registry_and_activation() {
 
     assert((log.entries == std::vector<std::string>{
         "create:main_menu",
+        "token:1",
         "arg:title=Main Menu",
         "activate",
     }));
@@ -100,12 +115,14 @@ void test_replace_tears_down_previous_screen() {
 
     assert((first_log.entries == std::vector<std::string>{
         "create:main_menu",
+        "token:1",
         "activate",
         "deactivate",
         "destroy",
     }));
     assert((second_log.entries == std::vector<std::string>{
         "create:scan_qr",
+        "token:2",
         "activate",
     }));
 }
@@ -141,8 +158,68 @@ void test_failed_replace_keeps_existing_screen() {
     assert(runtime.get_active_route()->route_id.value() == "main_menu");
     assert((log.entries == std::vector<std::string>{
         "create:main_menu",
+        "token:1",
         "activate",
     }));
+}
+
+void test_screen_can_emit_outbound_action_event() {
+    seedsigner::lvgl::UiRuntime runtime;
+    assert(runtime.init());
+
+    runtime.screen_registry().register_route(
+        seedsigner::lvgl::RouteId{"emit_action"},
+        []() { return std::make_unique<EventEmittingScreen>(); });
+
+    const auto active = runtime.activate({.route_id = seedsigner::lvgl::RouteId{"emit_action"}});
+    assert(active.has_value());
+
+    const auto screen_action = runtime.next_event();
+    assert(screen_action.has_value());
+    assert(screen_action->type == seedsigner::lvgl::EventType::ActionInvoked);
+    
+    const auto route_activated = runtime.next_event();
+    assert(route_activated.has_value());
+    assert(route_activated->type == seedsigner::lvgl::EventType::RouteActivated);
+    assert(screen_action->route_id.value() == "emit_action");
+    assert(screen_action->screen_token == active->screen_token);
+    assert(screen_action->component_id == std::optional<std::string>{"primary_button"});
+    assert(screen_action->action_id == std::optional<std::string>{"confirm"});
+    assert(std::get<std::int64_t>(*screen_action->value) == 1);
+    assert(screen_action->meta.has_value());
+    assert(screen_action->meta->key == "source");
+    assert(std::get<std::string>(screen_action->meta->value) == "screen");
+
+    const auto screen_ready = runtime.next_event();
+    assert(screen_ready.has_value());
+    assert(screen_ready->type == seedsigner::lvgl::EventType::ScreenReady);
+}
+
+void test_event_queue_overflow_keeps_fifo_order() {
+    seedsigner::lvgl::EventQueue queue{2};
+
+    assert(queue.push({.type = seedsigner::lvgl::EventType::RouteActivated,
+                       .route_id = seedsigner::lvgl::RouteId{"one"},
+                       .screen_token = 1,
+                       .timestamp_ms = 10}));
+    assert(queue.push({.type = seedsigner::lvgl::EventType::ScreenReady,
+                       .route_id = seedsigner::lvgl::RouteId{"one"},
+                       .screen_token = 1,
+                       .timestamp_ms = 11}));
+    assert(!queue.push({.type = seedsigner::lvgl::EventType::ActionInvoked,
+                        .route_id = seedsigner::lvgl::RouteId{"one"},
+                        .screen_token = 1,
+                        .timestamp_ms = 12}));
+
+    const auto first = queue.next();
+    const auto second = queue.next();
+    const auto empty = queue.next();
+
+    assert(first.has_value());
+    assert(first->type == seedsigner::lvgl::EventType::RouteActivated);
+    assert(second.has_value());
+    assert(second->type == seedsigner::lvgl::EventType::ScreenReady);
+    assert(!empty.has_value());
 }
 
 }  // namespace
@@ -152,6 +229,8 @@ int main() {
     test_replace_tears_down_previous_screen();
     test_unknown_route_does_not_install_screen();
     test_failed_replace_keeps_existing_screen();
+    test_screen_can_emit_outbound_action_event();
+    test_event_queue_overflow_keeps_fifo_order();
     tests::test_headless_runtime_bootstrap();
     return 0;
 }


### PR DESCRIPTION
## Summary
- wire the existing outbound FIFO into `ScreenContext` so screens can emit structured events directly
- stamp screen-emitted events with the active route/screen token while keeping polling via `UiRuntime::next_event()` as the primary retrieval path
- add focused tests for screen-originated action events and bounded FIFO overflow/ordering

## Why this targets #17
PR #17 already contains the practical runtime skeleton, queue type, and host-smoke path that #15 depends on. Opening this against `main` would mostly duplicate #17 (and transitively the shared navigation work from #16), so this stays as a narrow follow-up on top of the real runtime branch.

## Validation
- `cmake -S . -B build`
- `cmake --build build -j2`
- `ctest --test-dir build --output-on-failure`
- `./build/host_sim_demo`

Refs #15
