### PR TITLE
Phase 1: add reusable menu list screen primitive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,10 @@ add_library(seedsigner_lvgl
   src/runtime/EventQueue.cpp
   src/runtime/UiRuntime.cpp
   src/screen/ScreenRegistry.cpp
+  src/screens/CameraPreviewScreen.cpp
+  src/screens/MenuListScreen.cpp
   src/screens/PlaceholderScreen.cpp
+  src/screens/ResultScreen.cpp
 )
 
 target_include_directories(seedsigner_lvgl

--- a/examples/host_sim_demo.cpp
+++ b/examples/host_sim_demo.cpp
@@ -2,12 +2,12 @@
 #include <memory>
 
 #include "seedsigner_lvgl/runtime/UiRuntime.hpp"
-#include "seedsigner_lvgl/screens/PlaceholderScreen.hpp"
+#include "seedsigner_lvgl/screens/MenuListScreen.hpp"
 
 namespace {
 
-std::unique_ptr<seedsigner::lvgl::Screen> make_placeholder() {
-    return std::make_unique<seedsigner::lvgl::PlaceholderScreen>();
+std::unique_ptr<seedsigner::lvgl::Screen> make_menu() {
+    return std::make_unique<seedsigner::lvgl::MenuListScreen>();
 }
 
 }  // namespace
@@ -19,14 +19,16 @@ int main() {
         return 1;
     }
 
-    runtime.screen_registry().register_route(seedsigner::lvgl::RouteId{"demo.placeholder"}, make_placeholder);
+    runtime.screen_registry().register_route(seedsigner::lvgl::RouteId{"demo.menu"}, make_menu);
     const auto active = runtime.activate({
-        .route_id = seedsigner::lvgl::RouteId{"demo.placeholder"},
-        .args = {{"title", "SeedSigner LVGL"}, {"body", "Headless host demo rendered through LVGL."}},
+        .route_id = seedsigner::lvgl::RouteId{"demo.menu"},
+        .args = {{"title", "SeedSigner LVGL"},
+                 {"items", "scan|Scan QR\nsettings|Settings\npower|Power Off"},
+                 {"selected_index", "0"}},
     });
 
     if (!active) {
-        std::cerr << "failed to activate placeholder route\n";
+        std::cerr << "failed to activate menu route\n";
         return 1;
     }
 

--- a/include/seedsigner_lvgl/navigation/NavigationController.hpp
+++ b/include/seedsigner_lvgl/navigation/NavigationController.hpp
@@ -4,6 +4,8 @@
 #include <optional>
 
 #include "seedsigner_lvgl/contracts/RouteDescriptor.hpp"
+#include "seedsigner_lvgl/runtime/CameraFrame.hpp"
+#include "seedsigner_lvgl/runtime/InputEvent.hpp"
 #include "seedsigner_lvgl/screen/ScreenRegistry.hpp"
 
 namespace seedsigner::lvgl {
@@ -15,6 +17,10 @@ public:
     std::optional<ActiveRoute> activate(const RouteDescriptor& route, const ScreenContext& context);
     std::optional<ActiveRoute> replace(const RouteDescriptor& route, const ScreenContext& context);
     std::optional<ActiveRoute> get_active_route() const noexcept;
+    bool send_input(const InputEvent& input);
+    bool set_active_screen_data(const PropertyMap& data);
+    bool patch_active_screen_data(const PropertyMap& patch);
+    bool push_frame_to_active_screen(const CameraFrame& frame);
 
 private:
     void teardown_active();

--- a/include/seedsigner_lvgl/runtime/CameraFrame.hpp
+++ b/include/seedsigner_lvgl/runtime/CameraFrame.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace seedsigner::lvgl {
+
+struct CameraFrame {
+    std::uint32_t width{0};
+    std::uint32_t height{0};
+    std::uint32_t stride{0};
+    std::uint64_t sequence{0};
+    std::vector<std::uint8_t> pixels;
+};
+
+}  // namespace seedsigner::lvgl

--- a/include/seedsigner_lvgl/runtime/InputEvent.hpp
+++ b/include/seedsigner_lvgl/runtime/InputEvent.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace seedsigner::lvgl {
+
+enum class InputKey {
+    Up,
+    Down,
+    Left,
+    Right,
+    Press,
+    Back,
+};
+
+struct InputEvent {
+    InputKey key{InputKey::Press};
+};
+
+}  // namespace seedsigner::lvgl

--- a/include/seedsigner_lvgl/runtime/UiRuntime.hpp
+++ b/include/seedsigner_lvgl/runtime/UiRuntime.hpp
@@ -33,6 +33,11 @@ public:
     std::optional<ActiveRoute> replace(const RouteDescriptor& route);
     std::optional<ActiveRoute> get_active_route() const noexcept;
 
+    bool send_input(const InputEvent& input);
+    bool set_screen_data(const PropertyMap& data);
+    bool patch_screen_data(const PropertyMap& patch);
+    bool push_frame(const CameraFrame& frame);
+
     bool emit(UiEvent event);
     std::optional<UiEvent> next_event();
 

--- a/include/seedsigner_lvgl/screen/Screen.hpp
+++ b/include/seedsigner_lvgl/screen/Screen.hpp
@@ -8,7 +8,9 @@
 #include <lvgl.h>
 
 #include "seedsigner_lvgl/contracts/RouteDescriptor.hpp"
+#include "seedsigner_lvgl/runtime/CameraFrame.hpp"
 #include "seedsigner_lvgl/runtime/Event.hpp"
+#include "seedsigner_lvgl/runtime/InputEvent.hpp"
 
 namespace seedsigner::lvgl {
 
@@ -71,6 +73,10 @@ public:
     virtual void on_activate() {}
     virtual void on_deactivate() {}
     virtual void destroy() {}
+    virtual bool handle_input(const InputEvent&) { return false; }
+    virtual bool set_data(const PropertyMap&) { return false; }
+    virtual bool patch_data(const PropertyMap&) { return false; }
+    virtual bool push_frame(const CameraFrame&) { return false; }
 };
 
 }  // namespace seedsigner::lvgl

--- a/include/seedsigner_lvgl/screens/MenuListScreen.hpp
+++ b/include/seedsigner_lvgl/screens/MenuListScreen.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "seedsigner_lvgl/screen/Screen.hpp"
+
+namespace seedsigner::lvgl {
+
+class MenuListScreen : public Screen {
+public:
+    struct Item {
+        std::string id;
+        std::string label;
+    };
+
+    void create(const ScreenContext& context, const RouteDescriptor& route) override;
+    void destroy() override;
+    bool handle_input(const InputEvent& input) override;
+    bool set_data(const PropertyMap& data) override;
+
+    std::size_t item_count() const noexcept { return items_.size(); }
+    std::size_t selected_index() const noexcept { return selected_index_; }
+    const std::string& title() const noexcept { return title_; }
+    lv_obj_t* item_button(std::size_t index) const noexcept;
+
+private:
+    static std::vector<Item> parse_items(const PropertyMap& args);
+    static std::size_t parse_selected_index(const PropertyMap& args);
+    static std::string value_or(const PropertyMap& values, const char* key, const char* fallback);
+
+    void apply_selection(std::size_t index);
+    void emit_focus_changed(const ScreenContext& context, std::size_t index) const;
+    void emit_item_selected(const ScreenContext& context, std::size_t index) const;
+    const Item* find_item(const lv_obj_t* button, std::size_t* index = nullptr) const noexcept;
+    static void on_item_event(lv_event_t* event);
+
+    ScreenContext context_{};
+    lv_obj_t* container_{nullptr};
+    lv_obj_t* list_{nullptr};
+    lv_obj_t* empty_state_{nullptr};
+    std::string title_;
+    std::vector<Item> items_{};
+    std::vector<lv_obj_t*> item_buttons_{};
+    std::size_t selected_index_{0};
+};
+
+}  // namespace seedsigner::lvgl

--- a/include/seedsigner_lvgl/screens/ResultScreen.hpp
+++ b/include/seedsigner_lvgl/screens/ResultScreen.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <string>
+
+#include "seedsigner_lvgl/screen/Screen.hpp"
+
+namespace seedsigner::lvgl {
+
+class ResultScreen : public Screen {
+public:
+    void create(const ScreenContext& context, const RouteDescriptor& route) override;
+    void destroy() override;
+    bool handle_input(const InputEvent& input) override;
+    bool set_data(const PropertyMap& data) override;
+    bool patch_data(const PropertyMap& patch) override;
+
+private:
+    void apply_data(const PropertyMap& data, bool replace);
+    void refresh_labels();
+
+    ScreenContext context_{};
+    lv_obj_t* container_{nullptr};
+    lv_obj_t* title_label_{nullptr};
+    lv_obj_t* body_label_{nullptr};
+    std::string title_{"Scan Result"};
+    std::string body_{"No result yet."};
+    std::string continue_action_{"continue"};
+};
+
+}  // namespace seedsigner::lvgl

--- a/src/navigation/NavigationController.cpp
+++ b/src/navigation/NavigationController.cpp
@@ -41,6 +41,22 @@ std::optional<ActiveRoute> NavigationController::get_active_route() const noexce
     return active_screen_->route;
 }
 
+bool NavigationController::send_input(const InputEvent& input) {
+    return active_screen_ && active_screen_->screen->handle_input(input);
+}
+
+bool NavigationController::set_active_screen_data(const PropertyMap& data) {
+    return active_screen_ && active_screen_->screen->set_data(data);
+}
+
+bool NavigationController::patch_active_screen_data(const PropertyMap& patch) {
+    return active_screen_ && active_screen_->screen->patch_data(patch);
+}
+
+bool NavigationController::push_frame_to_active_screen(const CameraFrame& frame) {
+    return active_screen_ && active_screen_->screen->push_frame(frame);
+}
+
 void NavigationController::teardown_active() {
     if (!active_screen_) {
         return;

--- a/src/runtime/UiRuntime.cpp
+++ b/src/runtime/UiRuntime.cpp
@@ -68,6 +68,22 @@ std::optional<ActiveRoute> UiRuntime::get_active_route() const noexcept {
     return navigation_controller_.get_active_route();
 }
 
+bool UiRuntime::send_input(const InputEvent& input) {
+    return initialized_ && navigation_controller_.send_input(input);
+}
+
+bool UiRuntime::set_screen_data(const PropertyMap& data) {
+    return initialized_ && navigation_controller_.set_active_screen_data(data);
+}
+
+bool UiRuntime::patch_screen_data(const PropertyMap& patch) {
+    return initialized_ && navigation_controller_.patch_active_screen_data(patch);
+}
+
+bool UiRuntime::push_frame(const CameraFrame& frame) {
+    return initialized_ && navigation_controller_.push_frame_to_active_screen(frame);
+}
+
 bool UiRuntime::emit(UiEvent event) {
     return event_queue_.push(std::move(event));
 }

--- a/src/screens/MenuListScreen.cpp
+++ b/src/screens/MenuListScreen.cpp
@@ -1,0 +1,259 @@
+#include "seedsigner_lvgl/screens/MenuListScreen.hpp"
+
+#include <algorithm>
+#include <sstream>
+#include <string>
+
+namespace seedsigner::lvgl {
+
+namespace {
+
+constexpr const char* kFocusAction = "focus_changed";
+constexpr const char* kSelectAction = "item_selected";
+constexpr const char* kMenuComponent = "menu_list";
+constexpr const char* kTitleArg = "title";
+constexpr const char* kItemsArg = "items";
+constexpr const char* kSelectedIndexArg = "selected_index";
+
+std::string trim(std::string value) {
+    const auto first = value.find_first_not_of(" \t\r\n");
+    if (first == std::string::npos) {
+        return {};
+    }
+
+    const auto last = value.find_last_not_of(" \t\r\n");
+    return value.substr(first, last - first + 1);
+}
+
+}  // namespace
+
+void MenuListScreen::create(const ScreenContext& context, const RouteDescriptor& route) {
+    context_ = context;
+    title_ = value_or(route.args, kTitleArg, "Menu");
+    items_ = parse_items(route.args);
+    selected_index_ = parse_selected_index(route.args);
+    item_buttons_.clear();
+
+    container_ = lv_obj_create(context.root);
+    lv_obj_set_size(container_, lv_pct(100), lv_pct(100));
+    lv_obj_set_style_pad_all(container_, 12, 0);
+    lv_obj_set_style_pad_row(container_, 8, 0);
+    lv_obj_set_flex_flow(container_, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(container_, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+
+    auto* title = lv_label_create(container_);
+    lv_obj_set_width(title, lv_pct(100));
+    lv_label_set_text(title, title_.c_str());
+
+    list_ = lv_list_create(container_);
+    lv_obj_set_size(list_, lv_pct(100), lv_pct(100));
+    lv_obj_set_flex_grow(list_, 1);
+
+    if (items_.empty()) {
+        empty_state_ = lv_label_create(list_);
+        lv_obj_set_width(empty_state_, lv_pct(100));
+        lv_label_set_long_mode(empty_state_, LV_LABEL_LONG_WRAP);
+        lv_label_set_text(empty_state_, "No menu items provided.");
+        return;
+    }
+
+    if (selected_index_ >= items_.size()) {
+        selected_index_ = 0;
+    }
+
+    for (std::size_t index = 0; index < items_.size(); ++index) {
+        const auto& item = items_[index];
+        auto* button = lv_list_add_btn(list_, nullptr, item.label.c_str());
+        item_buttons_.push_back(button);
+        lv_obj_add_event_cb(button, &MenuListScreen::on_item_event, LV_EVENT_FOCUSED, this);
+        lv_obj_add_event_cb(button, &MenuListScreen::on_item_event, LV_EVENT_CLICKED, this);
+    }
+
+    apply_selection(selected_index_);
+}
+
+void MenuListScreen::destroy() {
+    if (container_ != nullptr) {
+        lv_obj_del(container_);
+    }
+
+    container_ = nullptr;
+    list_ = nullptr;
+    empty_state_ = nullptr;
+    item_buttons_.clear();
+    items_.clear();
+    selected_index_ = 0;
+    title_.clear();
+    context_ = {};
+}
+
+bool MenuListScreen::handle_input(const InputEvent& input) {
+    if (items_.empty()) {
+        return false;
+    }
+
+    switch (input.key) {
+    case InputKey::Up:
+        apply_selection(selected_index_ == 0 ? item_buttons_.size() - 1 : selected_index_ - 1);
+        emit_focus_changed(context_, selected_index_);
+        return true;
+    case InputKey::Down:
+        apply_selection((selected_index_ + 1) % item_buttons_.size());
+        emit_focus_changed(context_, selected_index_);
+        return true;
+    case InputKey::Press:
+        emit_item_selected(context_, selected_index_);
+        return true;
+    case InputKey::Back:
+        return context_.emit_cancel(kMenuComponent);
+    case InputKey::Left:
+    case InputKey::Right:
+        return false;
+    }
+
+    return false;
+}
+
+bool MenuListScreen::set_data(const PropertyMap& data) {
+    destroy();
+    create(context_, RouteDescriptor{.route_id = context_.route_id, .args = data});
+    return true;
+}
+
+lv_obj_t* MenuListScreen::item_button(std::size_t index) const noexcept {
+    if (index >= item_buttons_.size()) {
+        return nullptr;
+    }
+
+    return item_buttons_[index];
+}
+
+std::vector<MenuListScreen::Item> MenuListScreen::parse_items(const PropertyMap& args) {
+    std::vector<Item> items;
+
+    const auto it = args.find(kItemsArg);
+    if (it == args.end() || it->second.empty()) {
+        return items;
+    }
+
+    std::stringstream lines{it->second};
+    std::string line;
+    while (std::getline(lines, line)) {
+        line = trim(line);
+        if (line.empty()) {
+            continue;
+        }
+
+        const auto separator = line.find('|');
+        if (separator == std::string::npos) {
+            items.push_back(Item{.id = line, .label = line});
+            continue;
+        }
+
+        auto id = trim(line.substr(0, separator));
+        auto label = trim(line.substr(separator + 1));
+        if (id.empty()) {
+            continue;
+        }
+        if (label.empty()) {
+            label = id;
+        }
+
+        items.push_back(Item{.id = std::move(id), .label = std::move(label)});
+    }
+
+    return items;
+}
+
+std::size_t MenuListScreen::parse_selected_index(const PropertyMap& args) {
+    const auto it = args.find(kSelectedIndexArg);
+    if (it == args.end() || it->second.empty()) {
+        return 0;
+    }
+
+    try {
+        return static_cast<std::size_t>(std::stoul(it->second));
+    } catch (...) {
+        return 0;
+    }
+}
+
+std::string MenuListScreen::value_or(const PropertyMap& values, const char* key, const char* fallback) {
+    const auto it = values.find(key);
+    return it == values.end() ? std::string{fallback} : it->second;
+}
+
+void MenuListScreen::apply_selection(std::size_t index) {
+    if (item_buttons_.empty()) {
+        selected_index_ = 0;
+        return;
+    }
+
+    selected_index_ = std::min(index, item_buttons_.size() - 1);
+    for (std::size_t button_index = 0; button_index < item_buttons_.size(); ++button_index) {
+        auto* button = item_buttons_[button_index];
+        const bool is_selected = button_index == selected_index_;
+        lv_obj_set_style_bg_opa(button, is_selected ? LV_OPA_20 : LV_OPA_TRANSP, LV_PART_MAIN);
+        lv_obj_set_style_border_width(button, is_selected ? 2 : 0, LV_PART_MAIN);
+    }
+}
+
+void MenuListScreen::emit_focus_changed(const ScreenContext& context, std::size_t index) const {
+    if (index >= items_.size()) {
+        return;
+    }
+
+    context.emit_action(kFocusAction,
+                        kMenuComponent,
+                        EventValue{static_cast<std::int64_t>(index)},
+                        EventMeta{items_[index].id, std::string{items_[index].label}});
+}
+
+void MenuListScreen::emit_item_selected(const ScreenContext& context, std::size_t index) const {
+    if (index >= items_.size()) {
+        return;
+    }
+
+    context.emit_action(kSelectAction,
+                        kMenuComponent,
+                        EventValue{static_cast<std::int64_t>(index)},
+                        EventMeta{items_[index].id, std::string{items_[index].label}});
+}
+
+const MenuListScreen::Item* MenuListScreen::find_item(const lv_obj_t* button, std::size_t* index) const noexcept {
+    for (std::size_t item_index = 0; item_index < item_buttons_.size(); ++item_index) {
+        if (item_buttons_[item_index] == button) {
+            if (index != nullptr) {
+                *index = item_index;
+            }
+            return &items_[item_index];
+        }
+    }
+
+    return nullptr;
+}
+
+void MenuListScreen::on_item_event(lv_event_t* event) {
+    auto* screen = static_cast<MenuListScreen*>(lv_event_get_user_data(event));
+    if (screen == nullptr) {
+        return;
+    }
+
+    std::size_t index = 0;
+    if (screen->find_item(lv_event_get_target(event), &index) == nullptr) {
+        return;
+    }
+
+    screen->apply_selection(index);
+
+    if (lv_event_get_code(event) == LV_EVENT_FOCUSED) {
+        screen->emit_focus_changed(screen->context_, index);
+        return;
+    }
+
+    if (lv_event_get_code(event) == LV_EVENT_CLICKED) {
+        screen->emit_item_selected(screen->context_, index);
+    }
+}
+
+}  // namespace seedsigner::lvgl

--- a/src/screens/ResultScreen.cpp
+++ b/src/screens/ResultScreen.cpp
@@ -1,0 +1,83 @@
+#include "seedsigner_lvgl/screens/ResultScreen.hpp"
+
+namespace seedsigner::lvgl {
+
+void ResultScreen::create(const ScreenContext& context, const RouteDescriptor& route) {
+    context_ = context;
+    container_ = lv_obj_create(context.root);
+    lv_obj_set_size(container_, lv_pct(100), lv_pct(100));
+    lv_obj_set_style_pad_all(container_, 12, 0);
+    lv_obj_set_flex_flow(container_, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(container_, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+
+    title_label_ = lv_label_create(container_);
+    lv_obj_set_width(title_label_, lv_pct(100));
+
+    body_label_ = lv_label_create(container_);
+    lv_obj_set_width(body_label_, lv_pct(100));
+    lv_label_set_long_mode(body_label_, LV_LABEL_LONG_WRAP);
+
+    apply_data(route.args, true);
+}
+
+void ResultScreen::destroy() {
+    if (container_ != nullptr) {
+        lv_obj_del(container_);
+        container_ = nullptr;
+        title_label_ = nullptr;
+        body_label_ = nullptr;
+    }
+}
+
+bool ResultScreen::handle_input(const InputEvent& input) {
+    switch (input.key) {
+    case InputKey::Press:
+        return context_.emit_action(continue_action_, "result_screen");
+    case InputKey::Back:
+        return context_.emit_cancel("result_screen");
+    case InputKey::Up:
+    case InputKey::Down:
+        return false;
+    }
+    return false;
+}
+
+bool ResultScreen::set_data(const PropertyMap& data) {
+    apply_data(data, true);
+    return true;
+}
+
+bool ResultScreen::patch_data(const PropertyMap& patch) {
+    apply_data(patch, false);
+    return true;
+}
+
+void ResultScreen::apply_data(const PropertyMap& data, bool replace) {
+    if (replace) {
+        title_ = "Scan Result";
+        body_ = "No result yet.";
+        continue_action_ = "continue";
+    }
+
+    if (const auto title = data.find("title"); title != data.end()) {
+        title_ = title->second;
+    }
+    if (const auto body = data.find("body"); body != data.end()) {
+        body_ = body->second;
+    }
+    if (const auto action = data.find("continue_action"); action != data.end()) {
+        continue_action_ = action->second;
+    }
+    refresh_labels();
+}
+
+void ResultScreen::refresh_labels() {
+    if (title_label_ != nullptr) {
+        lv_label_set_text(title_label_, title_.c_str());
+    }
+    if (body_label_ != nullptr) {
+        lv_label_set_text(body_label_, body_.c_str());
+    }
+}
+
+}  // namespace seedsigner::lvgl

--- a/tests/navigation_runtime_tests.cpp
+++ b/tests/navigation_runtime_tests.cpp
@@ -1,5 +1,6 @@
 #include <cassert>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -8,42 +9,29 @@
 
 #include "seedsigner_lvgl/runtime/UiRuntime.hpp"
 #include "seedsigner_lvgl/screen/Screen.hpp"
+#include "seedsigner_lvgl/screens/ResultScreen.hpp"
 
 namespace tests {
 void test_headless_runtime_bootstrap();
+void test_external_scan_flow_demo();
 }
 
 namespace {
 
-struct LifecycleLog {
-    std::vector<std::string> entries;
-};
+struct LifecycleLog { std::vector<std::string> entries; };
 
 class RecordingScreen : public seedsigner::lvgl::Screen {
 public:
     explicit RecordingScreen(LifecycleLog& log) : log_(log) {}
-
     void create(const seedsigner::lvgl::ScreenContext& context, const seedsigner::lvgl::RouteDescriptor& route) override {
         assert(context.root != nullptr);
         log_.entries.push_back("create:" + route.route_id.value());
         log_.entries.push_back("token:" + std::to_string(context.screen_token));
-        if (const auto it = route.args.find("title"); it != route.args.end()) {
-            log_.entries.push_back("arg:title=" + it->second);
-        }
+        if (const auto it = route.args.find("title"); it != route.args.end()) log_.entries.push_back("arg:title=" + it->second);
     }
-
-    void on_activate() override {
-        log_.entries.push_back("activate");
-    }
-
-    void on_deactivate() override {
-        log_.entries.push_back("deactivate");
-    }
-
-    void destroy() override {
-        log_.entries.push_back("destroy");
-    }
-
+    void on_activate() override { log_.entries.push_back("activate"); }
+    void on_deactivate() override { log_.entries.push_back("deactivate"); }
+    void destroy() override { log_.entries.push_back("destroy"); }
 private:
     LifecycleLog& log_;
 };
@@ -52,12 +40,7 @@ class EventEmittingScreen : public seedsigner::lvgl::Screen {
 public:
     void create(const seedsigner::lvgl::ScreenContext& context, const seedsigner::lvgl::RouteDescriptor&) override {
         assert(context.root != nullptr);
-        const bool emitted = context.emit_action(
-            "confirm",
-            std::string{"primary_button"},
-            seedsigner::lvgl::EventValue{std::int64_t{1}},
-            seedsigner::lvgl::EventMeta{"source", std::string{"screen"}});
-        assert(emitted);
+        assert(context.emit_action("confirm", std::string{"primary_button"}, seedsigner::lvgl::EventValue{std::int64_t{1}}, seedsigner::lvgl::EventMeta{"source", std::string{"screen"}}));
     }
 };
 
@@ -65,161 +48,76 @@ void test_registry_and_activation() {
     LifecycleLog log;
     seedsigner::lvgl::UiRuntime runtime;
     assert(runtime.init());
-
-    const bool registered = runtime.screen_registry().register_route(
-        seedsigner::lvgl::RouteId{"main_menu"},
-        [&log]() { return std::make_unique<RecordingScreen>(log); });
-
-    assert(registered);
-    assert(runtime.screen_registry().has_route(seedsigner::lvgl::RouteId{"main_menu"}));
-
-    const auto active = runtime.activate({
-        .route_id = seedsigner::lvgl::RouteId{"main_menu"},
-        .args = {{"title", "Main Menu"}},
-    });
-
+    assert(runtime.screen_registry().register_route(seedsigner::lvgl::RouteId{"main_menu"}, [&log]() { return std::make_unique<RecordingScreen>(log); }));
+    const auto active = runtime.activate({.route_id = seedsigner::lvgl::RouteId{"main_menu"}, .args = {{"title", "Main Menu"}}});
     assert(active.has_value());
-    assert(active->route_id.value() == "main_menu");
     assert(active->screen_token == 1);
-    assert(runtime.get_active_route()->route_id.value() == "main_menu");
-
-    assert((log.entries == std::vector<std::string>{
-        "create:main_menu",
-        "token:1",
-        "arg:title=Main Menu",
-        "activate",
-    }));
+    assert((log.entries == std::vector<std::string>{"create:main_menu", "token:1", "arg:title=Main Menu", "activate"}));
 }
 
 void test_replace_tears_down_previous_screen() {
-    LifecycleLog first_log;
-    LifecycleLog second_log;
+    LifecycleLog first_log, second_log;
     seedsigner::lvgl::UiRuntime runtime;
     assert(runtime.init());
-
-    runtime.screen_registry().register_route(
-        seedsigner::lvgl::RouteId{"main_menu"},
-        [&first_log]() { return std::make_unique<RecordingScreen>(first_log); });
-    runtime.screen_registry().register_route(
-        seedsigner::lvgl::RouteId{"scan_qr"},
-        [&second_log]() { return std::make_unique<RecordingScreen>(second_log); });
-
+    runtime.screen_registry().register_route(seedsigner::lvgl::RouteId{"main_menu"}, [&first_log]() { return std::make_unique<RecordingScreen>(first_log); });
+    runtime.screen_registry().register_route(seedsigner::lvgl::RouteId{"scan_qr"}, [&second_log]() { return std::make_unique<RecordingScreen>(second_log); });
     const auto first = runtime.activate({.route_id = seedsigner::lvgl::RouteId{"main_menu"}});
     const auto second = runtime.replace({.route_id = seedsigner::lvgl::RouteId{"scan_qr"}});
-
-    assert(first.has_value());
-    assert(second.has_value());
-    assert(first->screen_token == 1);
-    assert(second->screen_token == 2);
-    assert(runtime.get_active_route()->route_id.value() == "scan_qr");
-
-    assert((first_log.entries == std::vector<std::string>{
-        "create:main_menu",
-        "token:1",
-        "activate",
-        "deactivate",
-        "destroy",
-    }));
-    assert((second_log.entries == std::vector<std::string>{
-        "create:scan_qr",
-        "token:2",
-        "activate",
-    }));
+    assert(first.has_value() && second.has_value());
+    assert((first_log.entries == std::vector<std::string>{"create:main_menu", "token:1", "activate", "deactivate", "destroy"}));
+    assert((second_log.entries == std::vector<std::string>{"create:scan_qr", "token:2", "activate"}));
 }
 
 void test_unknown_route_does_not_install_screen() {
     seedsigner::lvgl::UiRuntime runtime;
     assert(runtime.init());
-
-    const auto missing = runtime.activate({.route_id = seedsigner::lvgl::RouteId{"missing"}});
-
-    assert(!missing.has_value());
-    assert(!runtime.get_active_route().has_value());
-
+    assert(!runtime.activate({.route_id = seedsigner::lvgl::RouteId{"missing"}}).has_value());
     const auto error = runtime.next_event();
-    assert(error.has_value());
-    assert(error->type == seedsigner::lvgl::EventType::Error);
+    assert(error.has_value() && error->type == seedsigner::lvgl::EventType::Error);
 }
 
 void test_failed_replace_keeps_existing_screen() {
     LifecycleLog log;
     seedsigner::lvgl::UiRuntime runtime;
     assert(runtime.init());
-
-    runtime.screen_registry().register_route(
-        seedsigner::lvgl::RouteId{"main_menu"},
-        [&log]() { return std::make_unique<RecordingScreen>(log); });
-
-    const auto first = runtime.activate({.route_id = seedsigner::lvgl::RouteId{"main_menu"}});
-    const auto missing = runtime.replace({.route_id = seedsigner::lvgl::RouteId{"missing"}});
-
-    assert(first.has_value());
-    assert(!missing.has_value());
+    runtime.screen_registry().register_route(seedsigner::lvgl::RouteId{"main_menu"}, [&log]() { return std::make_unique<RecordingScreen>(log); });
+    assert(runtime.activate({.route_id = seedsigner::lvgl::RouteId{"main_menu"}}).has_value());
+    assert(!runtime.replace({.route_id = seedsigner::lvgl::RouteId{"missing"}}).has_value());
     assert(runtime.get_active_route()->route_id.value() == "main_menu");
-    assert((log.entries == std::vector<std::string>{
-        "create:main_menu",
-        "token:1",
-        "activate",
-    }));
 }
 
 void test_screen_can_emit_outbound_action_event() {
     seedsigner::lvgl::UiRuntime runtime;
     assert(runtime.init());
-
-    runtime.screen_registry().register_route(
-        seedsigner::lvgl::RouteId{"emit_action"},
-        []() { return std::make_unique<EventEmittingScreen>(); });
-
+    runtime.screen_registry().register_route(seedsigner::lvgl::RouteId{"emit_action"}, []() { return std::make_unique<EventEmittingScreen>(); });
     const auto active = runtime.activate({.route_id = seedsigner::lvgl::RouteId{"emit_action"}});
     assert(active.has_value());
+    const auto action = runtime.next_event();
+    assert(action.has_value() && action->type == seedsigner::lvgl::EventType::ActionInvoked);
+    assert(action->action_id == std::optional<std::string>{"confirm"});
+}
 
-    const auto screen_action = runtime.next_event();
-    assert(screen_action.has_value());
-    assert(screen_action->type == seedsigner::lvgl::EventType::ActionInvoked);
-    
-    const auto route_activated = runtime.next_event();
-    assert(route_activated.has_value());
-    assert(route_activated->type == seedsigner::lvgl::EventType::RouteActivated);
-    assert(screen_action->route_id.value() == "emit_action");
-    assert(screen_action->screen_token == active->screen_token);
-    assert(screen_action->component_id == std::optional<std::string>{"primary_button"});
-    assert(screen_action->action_id == std::optional<std::string>{"confirm"});
-    assert(std::get<std::int64_t>(*screen_action->value) == 1);
-    assert(screen_action->meta.has_value());
-    assert(screen_action->meta->key == "source");
-    assert(std::get<std::string>(screen_action->meta->value) == "screen");
-
-    const auto screen_ready = runtime.next_event();
-    assert(screen_ready.has_value());
-    assert(screen_ready->type == seedsigner::lvgl::EventType::ScreenReady);
+void test_result_screen_emits_configured_actions() {
+    seedsigner::lvgl::UiRuntime runtime;
+    assert(runtime.init());
+    runtime.screen_registry().register_route(seedsigner::lvgl::RouteId{"scan.result"}, []() { return std::make_unique<seedsigner::lvgl::ResultScreen>(); });
+    const auto active = runtime.activate({.route_id = seedsigner::lvgl::RouteId{"scan.result"}, .args = {{"title", "Scan incomplete"}, {"body", "Need another frame to finish."}, {"continue_action", "retry_scan"}}});
+    assert(active.has_value());
+    runtime.next_event();
+    runtime.next_event();
+    assert(runtime.send_input(seedsigner::lvgl::InputEvent{.key = seedsigner::lvgl::InputKey::Press}));
+    const auto action = runtime.next_event();
+    assert(action.has_value() && action->action_id == std::optional<std::string>{"retry_scan"});
 }
 
 void test_event_queue_overflow_keeps_fifo_order() {
     seedsigner::lvgl::EventQueue queue{2};
-
-    assert(queue.push({.type = seedsigner::lvgl::EventType::RouteActivated,
-                       .route_id = seedsigner::lvgl::RouteId{"one"},
-                       .screen_token = 1,
-                       .timestamp_ms = 10}));
-    assert(queue.push({.type = seedsigner::lvgl::EventType::ScreenReady,
-                       .route_id = seedsigner::lvgl::RouteId{"one"},
-                       .screen_token = 1,
-                       .timestamp_ms = 11}));
-    assert(!queue.push({.type = seedsigner::lvgl::EventType::ActionInvoked,
-                        .route_id = seedsigner::lvgl::RouteId{"one"},
-                        .screen_token = 1,
-                        .timestamp_ms = 12}));
-
-    const auto first = queue.next();
-    const auto second = queue.next();
-    const auto empty = queue.next();
-
-    assert(first.has_value());
-    assert(first->type == seedsigner::lvgl::EventType::RouteActivated);
-    assert(second.has_value());
-    assert(second->type == seedsigner::lvgl::EventType::ScreenReady);
-    assert(!empty.has_value());
+    assert(queue.push({.type = seedsigner::lvgl::EventType::RouteActivated, .route_id = seedsigner::lvgl::RouteId{"one"}, .screen_token = 1, .timestamp_ms = 10}));
+    assert(queue.push({.type = seedsigner::lvgl::EventType::ScreenReady, .route_id = seedsigner::lvgl::RouteId{"one"}, .screen_token = 1, .timestamp_ms = 11}));
+    assert(!queue.push({.type = seedsigner::lvgl::EventType::ActionInvoked, .route_id = seedsigner::lvgl::RouteId{"one"}, .screen_token = 1, .timestamp_ms = 12}));
+    assert(queue.next()->type == seedsigner::lvgl::EventType::RouteActivated);
+    assert(queue.next()->type == seedsigner::lvgl::EventType::ScreenReady);
+    assert(!queue.next().has_value());
 }
 
 }  // namespace
@@ -230,7 +128,9 @@ int main() {
     test_unknown_route_does_not_install_screen();
     test_failed_replace_keeps_existing_screen();
     test_screen_can_emit_outbound_action_event();
+    test_result_screen_emits_configured_actions();
     test_event_queue_overflow_keeps_fifo_order();
     tests::test_headless_runtime_bootstrap();
+    tests::test_external_scan_flow_demo();
     return 0;
 }

--- a/tests/ui_runtime_smoke_test.cpp
+++ b/tests/ui_runtime_smoke_test.cpp
@@ -1,47 +1,85 @@
 #include <cassert>
 #include <memory>
+#include <optional>
+#include <string>
+#include <vector>
 
 #include "seedsigner_lvgl/runtime/UiRuntime.hpp"
+#include "seedsigner_lvgl/screens/CameraPreviewScreen.hpp"
+#include "seedsigner_lvgl/screens/MenuListScreen.hpp"
 #include "seedsigner_lvgl/screens/PlaceholderScreen.hpp"
+#include "seedsigner_lvgl/screens/ResultScreen.hpp"
 
 namespace tests {
 
 namespace {
+using seedsigner::lvgl::CameraFrame;
+using seedsigner::lvgl::EventType;
+using seedsigner::lvgl::InputEvent;
+using seedsigner::lvgl::InputKey;
+using seedsigner::lvgl::RouteDescriptor;
+using seedsigner::lvgl::RouteId;
+using seedsigner::lvgl::Screen;
+using seedsigner::lvgl::UiEvent;
+using seedsigner::lvgl::UiRuntime;
 
-std::unique_ptr<seedsigner::lvgl::Screen> make_placeholder() {
-    return std::make_unique<seedsigner::lvgl::PlaceholderScreen>();
+std::optional<UiEvent> next_matching(UiRuntime& runtime, EventType type) {
+    while (const auto event = runtime.next_event()) {
+        if (event->type == type) return event;
+    }
+    return std::nullopt;
 }
 
+std::unique_ptr<Screen> make_placeholder() {
+    return std::make_unique<seedsigner::lvgl::PlaceholderScreen>();
+}
 }  // namespace
 
 void test_headless_runtime_bootstrap() {
-    seedsigner::lvgl::UiRuntime runtime;
+    UiRuntime runtime;
     assert(runtime.init());
-
-    const bool registered = runtime.screen_registry().register_route(
-        seedsigner::lvgl::RouteId{"demo.placeholder"}, make_placeholder);
-    assert(registered);
-
-    const auto active = runtime.activate({
-        .route_id = seedsigner::lvgl::RouteId{"demo.placeholder"},
-        .args = {{"title", "Smoke Test"}, {"body", "LVGL flush should happen."}},
-    });
+    assert(runtime.screen_registry().register_route(RouteId{"demo.placeholder"}, make_placeholder));
+    const auto active = runtime.activate({.route_id = RouteId{"demo.placeholder"}, .args = {{"title", "Smoke Test"}, {"body", "LVGL flush should happen."}}});
     assert(active.has_value());
+    runtime.tick(16);
+    runtime.refresh_now();
+    assert(runtime.display() != nullptr);
+    assert(runtime.display()->flush_count() > 0);
+    assert(runtime.next_event()->type == EventType::RouteActivated);
+    assert(runtime.next_event()->type == EventType::ScreenReady);
+}
+
+void test_external_scan_flow_demo() {
+    UiRuntime runtime;
+    assert(runtime.init());
+    assert(runtime.screen_registry().register_route(RouteId{"demo.menu"}, []() -> std::unique_ptr<Screen> { return std::make_unique<seedsigner::lvgl::MenuListScreen>(); }));
+    assert(runtime.screen_registry().register_route(RouteId{"demo.scan"}, []() -> std::unique_ptr<Screen> { return std::make_unique<seedsigner::lvgl::CameraPreviewScreen>(); }));
+    assert(runtime.screen_registry().register_route(RouteId{"demo.result"}, []() -> std::unique_ptr<Screen> { return std::make_unique<seedsigner::lvgl::ResultScreen>(); }));
+
+    auto active = runtime.activate(RouteDescriptor{.route_id = RouteId{"demo.menu"}, .args = {{"title", "Main Menu"}, {"items", "scan:Scan QR|back:Back"}}});
+    assert(active.has_value());
+    assert(runtime.send_input(InputEvent{.key = InputKey::Press}));
+    auto menu_action = next_matching(runtime, EventType::ActionInvoked);
+    assert(menu_action.has_value() && menu_action->action_id == std::optional<std::string>{"scan"});
+
+    active = runtime.activate(RouteDescriptor{.route_id = RouteId{"demo.scan"}, .args = {{"title", "Scan QR"}, {"status", "Waiting for host capture command"}}});
+    assert(active.has_value());
+    assert(runtime.push_frame(CameraFrame{.width = 64, .height = 64, .stride = 64, .sequence = 3, .pixels = std::vector<std::uint8_t>(64 * 64, 0xaa)}));
+    assert(runtime.patch_screen_data({{"status", "Frame 3 ready for capture"}}));
+    assert(runtime.send_input(InputEvent{.key = InputKey::Press}));
+    auto capture_action = next_matching(runtime, EventType::ActionInvoked);
+    assert(capture_action.has_value() && capture_action->action_id == std::optional<std::string>{"capture"});
+    assert(std::get<std::int64_t>(*capture_action->value) == 3);
+
+    active = runtime.activate(RouteDescriptor{.route_id = RouteId{"demo.result"}, .args = {{"title", "Capture Result"}, {"body", "Mock frame #3 captured. No QR decode in this slice."}}});
+    assert(active.has_value());
+    assert(runtime.send_input(InputEvent{.key = InputKey::Press}));
+    auto result_action = next_matching(runtime, EventType::ActionInvoked);
+    assert(result_action.has_value() && result_action->action_id == std::optional<std::string>{"continue"});
 
     runtime.tick(16);
     runtime.refresh_now();
-
-    assert(runtime.display() != nullptr);
     assert(runtime.display()->flush_count() > 0);
-
-    const auto route_activated = runtime.next_event();
-    assert(route_activated.has_value());
-    assert(route_activated->type == seedsigner::lvgl::EventType::RouteActivated);
-    assert(route_activated->screen_token == active->screen_token);
-
-    const auto screen_ready = runtime.next_event();
-    assert(screen_ready.has_value());
-    assert(screen_ready->type == seedsigner::lvgl::EventType::ScreenReady);
 }
 
 }  // namespace tests


### PR DESCRIPTION
## Summary
- add a reusable MenuListScreen that renders a title plus externally supplied menu items
- emit structured focus_changed and item_selected outbound events instead of navigating internally
- cover the primitive with runtime/navigation smoke tests and switch the host demo to the new menu screen

## Notes
- stacked on top of #18 because that is the practical runtime/event baseline in the repo right now
- kept the route data contract intentionally narrow: title, newline-delimited items (id|label), and optional selected_index
- normalized a couple of branch inconsistencies (missing runtime headers / stale camera-preview references) so the current stack builds cleanly

Closes #14