### PR TITLE
Phase 1: enrich menu list rows for settings-style screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Current implementation scope:
 - CMake-based C++/LVGL build bootstrap
 - headless host display integration for smoke validation
 - `UiRuntime` top-level owner with screen registry and outbound event queue scaffolding
-- structured SeedSigner-style menu/list screen with simple top-nav chrome and event-driven input handling
+- structured SeedSigner-style menu/list screen with simple top-nav chrome, two-line rows, and accessory/checkmark support for settings-style screens
 - host demo route and smoke tests for placeholder and menu flows
 
 Still intentionally out of scope:
@@ -44,6 +44,8 @@ ctest --test-dir build --output-on-failure
 ```
 
 The initial simulator target is deliberately headless. It uses LVGL with a dummy host display so the runtime, screen lifecycle, draw/flush path, and menu input/event behavior can be exercised in CI and on developer machines without committing yet to SDL or embedded platform glue.
+
+`MenuListScreen` now accepts either simple rows (`id|Label`) or richer structured rows (`id|Label|Secondary text|accessory`). The current accessory shortcuts are `check` and `chevron`, which are enough to start building settings-family and selector-family screens without inventing a new payload format yet.
 
 The repo now carries its own LVGL configuration in [`config/lv_conf.h`](config/lv_conf.h), so host builds do not require contributors to copy `lv_conf_template.h` or maintain a machine-local `lv_conf.h`.
 

--- a/docs/discovery/seedsigner-screen-parity-matrix.md
+++ b/docs/discovery/seedsigner-screen-parity-matrix.md
@@ -49,7 +49,7 @@ Implemented in `main` today:
 | Seed word entry / passphrase entry / coin-flip / dice / numeric-entry keyboards | Data entry / keyboard | Very High | **none** | Reusable keyboard framework, alternate layouts, cursor model, text editing, side soft-buttons | Biggest missing interaction family after simple menus/scan shell. |
 | Transaction review family (`PSBTOverviewScreen`, math/details/finalize) | Transaction review | Very High | **none** | Bitcoin formatting widgets, diagrams, address formatting, review pagination, approval UX | No meaningful parity started. |
 | Seed reveal / backup / transcription / verification custom screens | Sensitive seed management | Very High | **none** | Warning chrome, pagination, QR display, keyboard/input, custom overlays | Large domain still untouched beyond generic primitives. |
-| Settings entry update selection / locale selection | Settings / structured lists | Medium | **primitive-adjacent only** | Need checkbox/checkmark rows, help text, multiselect/singleselect behavior | Natural next consumer once list-row richness improves. |
+| Settings entry update selection / locale selection | Settings / structured lists | Medium | **partial** via richer `MenuListScreen` rows | Need true single/multi-select semantics, route-specific payload schema, help/footer chrome | Secondary text plus checkmark/chevron accessories now cover the first realistic settings-list shell, but not full settings flow behavior yet. |
 | Address explorer lists / address detail export | Tools / structured data views | High | **none** | Fixed-width address rows, pagination, QR display, derivation/fingerprint widgets | Blocked on formatted data components and QR display. |
 
 ## What is genuinely covered now
@@ -121,11 +121,10 @@ Why this next:
 ### Concrete scope for that block
 
 1. Add a **top-nav + standard screen chrome** wrapper
-2. Extend menu rows to support:
-   - primary label
-   - secondary text
-   - optional icon
-   - optional checkmark / accessory
+2. Finish the list-family shell with:
+   - optional icon support
+   - explicit single/multi-select semantics
+   - help/footer copy regions
 3. Add **scroll cues / pagination behavior**
 4. Add at least 2 real route implementations using the family:
    - main menu

--- a/examples/host_sim_demo.cpp
+++ b/examples/host_sim_demo.cpp
@@ -28,11 +28,16 @@ int main() {
     runtime.screen_registry().register_route(RouteId{"demo.scan"}, []() -> std::unique_ptr<Screen> { return std::make_unique<CameraPreviewScreen>(); });
     runtime.screen_registry().register_route(RouteId{"demo.result"}, []() -> std::unique_ptr<Screen> { return std::make_unique<ResultScreen>(); });
 
-    runtime.activate({.route_id = RouteId{"demo.menu"}, .args = {{"title", "SeedSigner Demo"}, {"items", "scan|Scan QR\nback|Back"}}});
+    runtime.activate({.route_id = RouteId{"demo.menu"}, .args = {{"title", "Settings"}, {"items", "network|Network|Configure host bridge|chevron\ndisplay|Persistent display|Keep screen awake while plugged in|check\nscan|Scan QR demo|Open the camera preview shell|chevron"}}});
     runtime.send_input(InputEvent{.key = InputKey::Press});
     const auto menu_action = next_matching(runtime, EventType::ActionInvoked);
-    if (!menu_action || !menu_action->meta || menu_action->meta->key != "scan") return 2;
+    if (!menu_action || !menu_action->meta || menu_action->meta->key != "network") return 2;
     std::cout << "menu selected=" << menu_action->meta->key << "\n";
+
+    runtime.send_input(InputEvent{.key = InputKey::Down});
+    const auto focus = next_matching(runtime, EventType::ActionInvoked);
+    if (!focus || !focus->meta || focus->meta->key != "display") return 5;
+    std::cout << "menu focus=" << focus->meta->key << "\n";
 
     runtime.activate({.route_id = RouteId{"demo.scan"}, .args = {{"title", "Camera Preview"}, {"status", "Controller waiting for capture"}}});
     runtime.push_frame(CameraFrame{.width = 96, .height = 96, .stride = 96, .sequence = 1, .pixels = std::vector<std::uint8_t>(96 * 96, 0x7f)});

--- a/include/seedsigner_lvgl/screens/MenuListScreen.hpp
+++ b/include/seedsigner_lvgl/screens/MenuListScreen.hpp
@@ -13,6 +13,8 @@ public:
     struct Item {
         std::string id;
         std::string label;
+        std::string secondary_text;
+        std::string accessory;
     };
 
     void create(const ScreenContext& context, const RouteDescriptor& route) override;
@@ -40,9 +42,15 @@ private:
     lv_obj_t* container_{nullptr};
     lv_obj_t* list_{nullptr};
     lv_obj_t* empty_state_{nullptr};
+    lv_style_t selected_row_style_{};
+    lv_style_t row_style_{};
+    bool styles_initialized_{false};
     std::string title_;
     std::vector<Item> items_{};
     std::vector<lv_obj_t*> item_buttons_{};
+    std::vector<lv_obj_t*> item_primary_labels_{};
+    std::vector<lv_obj_t*> item_secondary_labels_{};
+    std::vector<lv_obj_t*> item_accessory_labels_{};
     std::size_t selected_index_{0};
 };
 

--- a/src/screens/MenuListScreen.cpp
+++ b/src/screens/MenuListScreen.cpp
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <sstream>
 #include <string>
+#include <string_view>
+#include <utility>
 
 namespace seedsigner::lvgl {
 
@@ -25,6 +27,19 @@ std::string trim(std::string value) {
     return value.substr(first, last - first + 1);
 }
 
+const char* accessory_glyph(std::string_view accessory) {
+    if (accessory == "check" || accessory == "checked" || accessory == "selected") {
+        return LV_SYMBOL_OK;
+    }
+    if (accessory == "chevron" || accessory == "next") {
+        return LV_SYMBOL_RIGHT;
+    }
+    if (accessory == "toggle_on") {
+        return LV_SYMBOL_OK " on";
+    }
+    return nullptr;
+}
+
 }  // namespace
 
 void MenuListScreen::create(const ScreenContext& context, const RouteDescriptor& route) {
@@ -33,6 +48,26 @@ void MenuListScreen::create(const ScreenContext& context, const RouteDescriptor&
     items_ = parse_items(route.args);
     selected_index_ = parse_selected_index(route.args);
     item_buttons_.clear();
+    item_primary_labels_.clear();
+    item_secondary_labels_.clear();
+    item_accessory_labels_.clear();
+
+    if (!styles_initialized_) {
+        lv_style_init(&row_style_);
+        lv_style_set_radius(&row_style_, 8);
+        lv_style_set_pad_all(&row_style_, 10);
+        lv_style_set_pad_gap(&row_style_, 8);
+        lv_style_set_bg_opa(&row_style_, LV_OPA_TRANSP);
+        lv_style_set_border_width(&row_style_, 1);
+        lv_style_set_border_color(&row_style_, lv_palette_lighten(LV_PALETTE_GREY, 1));
+
+        lv_style_init(&selected_row_style_);
+        lv_style_set_bg_opa(&selected_row_style_, LV_OPA_20);
+        lv_style_set_bg_color(&selected_row_style_, lv_palette_main(LV_PALETTE_BLUE));
+        lv_style_set_border_width(&selected_row_style_, 2);
+        lv_style_set_border_color(&selected_row_style_, lv_palette_main(LV_PALETTE_BLUE));
+        styles_initialized_ = true;
+    }
 
     container_ = lv_obj_create(context.root);
     lv_obj_set_size(container_, lv_pct(100), lv_pct(100));
@@ -45,9 +80,14 @@ void MenuListScreen::create(const ScreenContext& context, const RouteDescriptor&
     lv_obj_set_width(title, lv_pct(100));
     lv_label_set_text(title, title_.c_str());
 
-    list_ = lv_list_create(container_);
+    list_ = lv_obj_create(container_);
     lv_obj_set_size(list_, lv_pct(100), lv_pct(100));
     lv_obj_set_flex_grow(list_, 1);
+    lv_obj_set_scroll_dir(list_, LV_DIR_VER);
+    lv_obj_set_flex_flow(list_, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(list_, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+    lv_obj_set_style_pad_all(list_, 0, 0);
+    lv_obj_set_style_pad_row(list_, 8, 0);
 
     if (items_.empty()) {
         empty_state_ = lv_label_create(list_);
@@ -63,10 +103,51 @@ void MenuListScreen::create(const ScreenContext& context, const RouteDescriptor&
 
     for (std::size_t index = 0; index < items_.size(); ++index) {
         const auto& item = items_[index];
-        auto* button = lv_list_add_btn(list_, nullptr, item.label.c_str());
-        item_buttons_.push_back(button);
+        auto* button = lv_btn_create(list_);
+        lv_obj_set_width(button, lv_pct(100));
+        lv_obj_set_style_min_height(button, item.secondary_text.empty() ? 46 : 64, 0);
+        lv_obj_set_flex_flow(button, LV_FLEX_FLOW_ROW);
+        lv_obj_set_flex_align(button, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+        lv_obj_add_style(button, &row_style_, LV_PART_MAIN);
         lv_obj_add_event_cb(button, &MenuListScreen::on_item_event, LV_EVENT_FOCUSED, this);
         lv_obj_add_event_cb(button, &MenuListScreen::on_item_event, LV_EVENT_CLICKED, this);
+
+        auto* text_column = lv_obj_create(button);
+        lv_obj_set_flex_grow(text_column, 1);
+        lv_obj_set_height(text_column, LV_SIZE_CONTENT);
+        lv_obj_set_style_bg_opa(text_column, LV_OPA_TRANSP, 0);
+        lv_obj_set_style_border_width(text_column, 0, 0);
+        lv_obj_set_style_pad_all(text_column, 0, 0);
+        lv_obj_set_style_pad_row(text_column, 2, 0);
+        lv_obj_set_flex_flow(text_column, LV_FLEX_FLOW_COLUMN);
+        lv_obj_clear_flag(text_column, LV_OBJ_FLAG_SCROLLABLE);
+
+        auto* primary = lv_label_create(text_column);
+        lv_obj_set_width(primary, lv_pct(100));
+        lv_label_set_long_mode(primary, LV_LABEL_LONG_DOT);
+        lv_label_set_text(primary, item.label.c_str());
+
+        lv_obj_t* secondary = nullptr;
+        if (!item.secondary_text.empty()) {
+            secondary = lv_label_create(text_column);
+            lv_obj_set_width(secondary, lv_pct(100));
+            lv_label_set_long_mode(secondary, LV_LABEL_LONG_DOT);
+            lv_obj_set_style_text_opa(secondary, LV_OPA_70, 0);
+            lv_label_set_text(secondary, item.secondary_text.c_str());
+        }
+
+        lv_obj_t* accessory = nullptr;
+        if (!item.accessory.empty()) {
+            accessory = lv_label_create(button);
+            const char* glyph = accessory_glyph(item.accessory);
+            lv_label_set_text(accessory, glyph != nullptr ? glyph : item.accessory.c_str());
+            lv_obj_set_style_text_align(accessory, LV_TEXT_ALIGN_RIGHT, 0);
+        }
+
+        item_buttons_.push_back(button);
+        item_primary_labels_.push_back(primary);
+        item_secondary_labels_.push_back(secondary);
+        item_accessory_labels_.push_back(accessory);
     }
 
     apply_selection(selected_index_);
@@ -81,6 +162,9 @@ void MenuListScreen::destroy() {
     list_ = nullptr;
     empty_state_ = nullptr;
     item_buttons_.clear();
+    item_primary_labels_.clear();
+    item_secondary_labels_.clear();
+    item_accessory_labels_.clear();
     items_.clear();
     selected_index_ = 0;
     title_.clear();
@@ -145,22 +229,22 @@ std::vector<MenuListScreen::Item> MenuListScreen::parse_items(const PropertyMap&
             continue;
         }
 
-        const auto separator = line.find('|');
-        if (separator == std::string::npos) {
-            items.push_back(Item{.id = line, .label = line});
+        std::vector<std::string> parts;
+        std::stringstream columns{line};
+        std::string part;
+        while (std::getline(columns, part, '|')) {
+            parts.push_back(trim(part));
+        }
+
+        if (parts.empty() || parts[0].empty()) {
             continue;
         }
 
-        auto id = trim(line.substr(0, separator));
-        auto label = trim(line.substr(separator + 1));
-        if (id.empty()) {
-            continue;
-        }
-        if (label.empty()) {
-            label = id;
-        }
-
-        items.push_back(Item{.id = std::move(id), .label = std::move(label)});
+        Item item{.id = parts[0],
+                  .label = parts.size() >= 2 && !parts[1].empty() ? parts[1] : parts[0],
+                  .secondary_text = parts.size() >= 3 ? parts[2] : std::string{},
+                  .accessory = parts.size() >= 4 ? parts[3] : std::string{}};
+        items.push_back(std::move(item));
     }
 
     return items;
@@ -193,9 +277,11 @@ void MenuListScreen::apply_selection(std::size_t index) {
     selected_index_ = std::min(index, item_buttons_.size() - 1);
     for (std::size_t button_index = 0; button_index < item_buttons_.size(); ++button_index) {
         auto* button = item_buttons_[button_index];
-        const bool is_selected = button_index == selected_index_;
-        lv_obj_set_style_bg_opa(button, is_selected ? LV_OPA_20 : LV_OPA_TRANSP, LV_PART_MAIN);
-        lv_obj_set_style_border_width(button, is_selected ? 2 : 0, LV_PART_MAIN);
+        lv_obj_remove_style(button, &selected_row_style_, LV_PART_MAIN);
+        if (button_index == selected_index_) {
+            lv_obj_add_style(button, &selected_row_style_, LV_PART_MAIN);
+            lv_obj_scroll_to_view(button, LV_ANIM_OFF);
+        }
     }
 }
 

--- a/tests/ui_runtime_smoke_test.cpp
+++ b/tests/ui_runtime_smoke_test.cpp
@@ -56,13 +56,19 @@ void test_external_scan_flow_demo() {
     assert(runtime.screen_registry().register_route(RouteId{"demo.scan"}, []() -> std::unique_ptr<Screen> { return std::make_unique<seedsigner::lvgl::CameraPreviewScreen>(); }));
     assert(runtime.screen_registry().register_route(RouteId{"demo.result"}, []() -> std::unique_ptr<Screen> { return std::make_unique<seedsigner::lvgl::ResultScreen>(); }));
 
-    auto active = runtime.activate(RouteDescriptor{.route_id = RouteId{"demo.menu"}, .args = {{"title", "Main Menu"}, {"items", "scan|Scan QR\nback|Back"}}});
+    auto active = runtime.activate(RouteDescriptor{.route_id = RouteId{"demo.menu"}, .args = {{"title", "Settings"}, {"items", "network|Network|Configure host bridge|chevron\ndisplay|Persistent display|Keep screen awake while plugged in|check\nback|Back"}}});
     assert(active.has_value());
     assert(runtime.send_input(InputEvent{.key = InputKey::Press}));
     auto menu_action = next_matching(runtime, EventType::ActionInvoked);
     assert(menu_action.has_value() && menu_action->action_id == std::optional<std::string>{"item_selected"});
     assert(menu_action->meta.has_value());
-    assert(menu_action->meta->key == "scan");
+    assert(menu_action->meta->key == "network");
+
+    assert(runtime.send_input(InputEvent{.key = InputKey::Down}));
+    auto focus_event = next_matching(runtime, EventType::ActionInvoked);
+    assert(focus_event.has_value() && focus_event->action_id == std::optional<std::string>{"focus_changed"});
+    assert(focus_event->meta.has_value());
+    assert(focus_event->meta->key == "display");
 
     active = runtime.activate(RouteDescriptor{.route_id = RouteId{"demo.scan"}, .args = {{"title", "Scan QR"}, {"status", "Waiting for host capture command"}}});
     assert(active.has_value());


### PR DESCRIPTION
## Summary
- extend MenuListScreen rows to support secondary text and simple accessory glyphs
- keep the existing compact items payload format while allowing id|Label|Secondary text|accessory
- update the host demo and smoke flow to exercise settings-style list rows
- update the parity matrix to reflect that settings-family structured lists are now partially covered

## Why this scope
This is the next clean block after the Phase 1 reconciliation work: it improves the existing list primitive in a reviewable way without pretending the full SeedSigner shell or settings flow semantics are done.

## Validation
- cmake -S . -B build-subagent -G 'Unix Makefiles'
- cmake --build build-subagent
- ctest --test-dir build-subagent --output-on-failure
- ./build-subagent/host_sim_demo
