### PR TITLE
Render grayscale frames in CameraPreviewScreen

### DIFF
--- a/docs/camera/CAMERA_CONTRACT.md
+++ b/docs/camera/CAMERA_CONTRACT.md
@@ -157,6 +157,11 @@ After the call returns:
 
 This single rule removes most binding and driver lifetime ambiguity.
 
+Current host implementation note:
+- `CameraPreviewScreen::push_frame(...)` immediately copies the caller-provided grayscale bytes into screen-owned storage before any LVGL redraw happens
+- the screen then rescales that retained frame into its own LVGL canvas buffer for presentation
+- tests validate the rendered canvas output directly, not just metadata labels
+
 ## 5.2 Internal ownership
 The UI module owns:
 - the staging buffer or buffers used for active camera surfaces

--- a/examples/host_sim_demo.cpp
+++ b/examples/host_sim_demo.cpp
@@ -40,7 +40,16 @@ int main() {
     std::cout << "menu focus=" << focus->meta->key << "\n";
 
     runtime.activate({.route_id = RouteId{"demo.scan"}, .args = {{"title", "Camera Preview"}, {"status", "Controller waiting for capture"}}});
-    runtime.push_frame(CameraFrame{.width = 96, .height = 96, .stride = 96, .sequence = 1, .pixels = std::vector<std::uint8_t>(96 * 96, 0x7f)});
+    std::vector<std::uint8_t> preview_pixels(96 * 96, 0x18);
+    for (std::uint32_t y = 0; y < 96; ++y) {
+        for (std::uint32_t x = 32; x < 64; ++x) {
+            preview_pixels[static_cast<std::size_t>(y) * 96 + x] = 0x88;
+        }
+        for (std::uint32_t x = 64; x < 96; ++x) {
+            preview_pixels[static_cast<std::size_t>(y) * 96 + x] = 0xf0;
+        }
+    }
+    runtime.push_frame(CameraFrame{.width = 96, .height = 96, .stride = 96, .sequence = 1, .pixels = std::move(preview_pixels)});
     runtime.send_input(InputEvent{.key = InputKey::Press});
     const auto capture = next_matching(runtime, EventType::ActionInvoked);
     if (!capture || capture->action_id != std::optional<std::string>{"capture"}) return 3;

--- a/include/seedsigner_lvgl/screens/CameraPreviewScreen.hpp
+++ b/include/seedsigner_lvgl/screens/CameraPreviewScreen.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include "seedsigner_lvgl/screen/Screen.hpp"
 
@@ -17,19 +18,24 @@ public:
 
 private:
     void apply_data(const PropertyMap& data, bool replace);
+    void refresh_preview();
     void refresh_labels();
 
     ScreenContext context_{};
     lv_obj_t* container_{nullptr};
     lv_obj_t* title_label_{nullptr};
     lv_obj_t* preview_panel_{nullptr};
+    lv_obj_t* preview_canvas_{nullptr};
     lv_obj_t* frame_label_{nullptr};
     lv_obj_t* status_label_{nullptr};
+    std::vector<lv_color_t> preview_canvas_buffer_{};
+    std::vector<std::uint8_t> latest_frame_{};
     std::string title_{"Scan QR"};
     std::string status_{"Waiting for external frames"};
     std::uint64_t frame_sequence_{0};
     std::uint32_t frame_width_{0};
     std::uint32_t frame_height_{0};
+    std::uint32_t frame_stride_{0};
     std::size_t frame_bytes_{0};
 };
 

--- a/src/screens/CameraPreviewScreen.cpp
+++ b/src/screens/CameraPreviewScreen.cpp
@@ -1,6 +1,17 @@
 #include "seedsigner_lvgl/screens/CameraPreviewScreen.hpp"
 
+#include <algorithm>
+
 namespace seedsigner::lvgl {
+namespace {
+constexpr lv_coord_t kPreviewWidth = 216;
+constexpr lv_coord_t kPreviewHeight = 144;
+constexpr lv_coord_t kPreviewPadding = 6;
+
+lv_color_t grayscale_to_color(std::uint8_t value) {
+    return lv_color_make(value, value, value);
+}
+}  // namespace
 
 void CameraPreviewScreen::create(const ScreenContext& context, const RouteDescriptor& route) {
     context_ = context;
@@ -16,24 +27,38 @@ void CameraPreviewScreen::create(const ScreenContext& context, const RouteDescri
     preview_panel_ = lv_obj_create(container_);
     lv_obj_set_size(preview_panel_, lv_pct(100), 180);
     lv_obj_set_style_bg_color(preview_panel_, lv_palette_darken(LV_PALETTE_GREY, 2), 0);
+    lv_obj_set_style_pad_all(preview_panel_, kPreviewPadding, 0);
+
+    preview_canvas_buffer_.resize(static_cast<std::size_t>(kPreviewWidth) * static_cast<std::size_t>(kPreviewHeight));
+    preview_canvas_ = lv_canvas_create(preview_panel_);
+    lv_canvas_set_buffer(preview_canvas_, preview_canvas_buffer_.data(), kPreviewWidth, kPreviewHeight,
+                         LV_IMG_CF_TRUE_COLOR);
+    lv_obj_center(preview_canvas_);
 
     frame_label_ = lv_label_create(preview_panel_);
-    lv_obj_center(frame_label_);
+    lv_obj_align(frame_label_, LV_ALIGN_BOTTOM_LEFT, 2, 2);
+    lv_obj_set_style_bg_opa(frame_label_, LV_OPA_60, 0);
+    lv_obj_set_style_bg_color(frame_label_, lv_color_black(), 0);
+    lv_obj_set_style_text_color(frame_label_, lv_color_white(), 0);
+    lv_obj_set_style_pad_all(frame_label_, 4, 0);
 
     status_label_ = lv_label_create(container_);
     lv_obj_set_width(status_label_, lv_pct(100));
     lv_label_set_long_mode(status_label_, LV_LABEL_LONG_WRAP);
 
     apply_data(route.args, true);
+    refresh_preview();
     context_.emit_needs_data("camera.frame", "preview_surface");
 }
 
 void CameraPreviewScreen::destroy() {
+    preview_canvas_buffer_.clear();
     if (container_ != nullptr) {
         lv_obj_del(container_);
         container_ = nullptr;
         title_label_ = nullptr;
         preview_panel_ = nullptr;
+        preview_canvas_ = nullptr;
         frame_label_ = nullptr;
         status_label_ = nullptr;
     }
@@ -67,7 +92,13 @@ bool CameraPreviewScreen::push_frame(const CameraFrame& frame) {
     frame_sequence_ = frame.sequence;
     frame_width_ = frame.width;
     frame_height_ = frame.height;
+    frame_stride_ = frame.stride;
     frame_bytes_ = frame.pixels.size();
+    latest_frame_ = frame.pixels;
+
+    // The producer only lends frame memory for the duration of push_frame(); keep our own copy so
+    // LVGL never reads caller-owned pixels after the call returns.
+    refresh_preview();
     refresh_labels();
     return true;
 }
@@ -79,7 +110,9 @@ void CameraPreviewScreen::apply_data(const PropertyMap& data, bool replace) {
         frame_sequence_ = 0;
         frame_width_ = 0;
         frame_height_ = 0;
+        frame_stride_ = 0;
         frame_bytes_ = 0;
+        latest_frame_.clear();
     }
 
     if (const auto title = data.find("title"); title != data.end()) {
@@ -91,14 +124,56 @@ void CameraPreviewScreen::apply_data(const PropertyMap& data, bool replace) {
     refresh_labels();
 }
 
+void CameraPreviewScreen::refresh_preview() {
+    if (preview_canvas_ == nullptr || preview_canvas_buffer_.empty()) {
+        return;
+    }
+
+    const lv_color_t panel_bg = lv_palette_darken(LV_PALETTE_GREY, 2);
+    lv_canvas_fill_bg(preview_canvas_, panel_bg, LV_OPA_COVER);
+
+    if (frame_width_ == 0 || frame_height_ == 0 || latest_frame_.empty()) {
+        return;
+    }
+
+    const auto source_stride = frame_stride_ == 0 ? frame_width_ : frame_stride_;
+    if (source_stride < frame_width_) {
+        return;
+    }
+    if (latest_frame_.size() < static_cast<std::size_t>(source_stride) * static_cast<std::size_t>(frame_height_)) {
+        return;
+    }
+
+    const auto target_width = static_cast<std::uint32_t>(kPreviewWidth);
+    const auto target_height = static_cast<std::uint32_t>(kPreviewHeight);
+    const std::uint32_t scaled_width =
+        std::max<std::uint32_t>(1, std::min<std::uint32_t>(target_width, (frame_width_ * target_height) / frame_height_));
+    const std::uint32_t scaled_height =
+        std::max<std::uint32_t>(1, std::min<std::uint32_t>(target_height, (frame_height_ * target_width) / frame_width_));
+    const std::uint32_t x_offset = (target_width - scaled_width) / 2;
+    const std::uint32_t y_offset = (target_height - scaled_height) / 2;
+
+    for (std::uint32_t y = 0; y < scaled_height; ++y) {
+        const auto src_y = std::min<std::uint32_t>(frame_height_ - 1, (y * frame_height_) / scaled_height);
+        for (std::uint32_t x = 0; x < scaled_width; ++x) {
+            const auto src_x = std::min<std::uint32_t>(frame_width_ - 1, (x * frame_width_) / scaled_width);
+            const auto value = latest_frame_[static_cast<std::size_t>(src_y) * source_stride + src_x];
+            lv_canvas_set_px(preview_canvas_, static_cast<lv_coord_t>(x + x_offset), static_cast<lv_coord_t>(y + y_offset),
+                             grayscale_to_color(value));
+        }
+    }
+
+    lv_obj_invalidate(preview_canvas_);
+}
+
 void CameraPreviewScreen::refresh_labels() {
     if (title_label_ != nullptr) {
         lv_label_set_text(title_label_, title_.c_str());
     }
     if (frame_label_ != nullptr) {
-        const std::string text = "frame #" + std::to_string(frame_sequence_) + "\n" +
+        const std::string text = "#" + std::to_string(frame_sequence_) + "  " +
                                  std::to_string(frame_width_) + "x" + std::to_string(frame_height_) +
-                                 "\nbytes=" + std::to_string(frame_bytes_);
+                                 "  stride=" + std::to_string(frame_stride_ == 0 ? frame_width_ : frame_stride_);
         lv_label_set_text(frame_label_, text.c_str());
     }
     if (status_label_ != nullptr) {

--- a/tests/ui_runtime_smoke_test.cpp
+++ b/tests/ui_runtime_smoke_test.cpp
@@ -4,6 +4,8 @@
 #include <string>
 #include <vector>
 
+#include <lvgl.h>
+
 #include "seedsigner_lvgl/runtime/UiRuntime.hpp"
 #include "seedsigner_lvgl/screens/CameraPreviewScreen.hpp"
 #include "seedsigner_lvgl/screens/MenuListScreen.hpp"
@@ -32,6 +34,23 @@ std::optional<UiEvent> next_matching(UiRuntime& runtime, EventType type) {
 
 std::unique_ptr<Screen> make_placeholder() {
     return std::make_unique<seedsigner::lvgl::PlaceholderScreen>();
+}
+
+lv_obj_t* find_first_canvas(lv_obj_t* root) {
+    if (root == nullptr) {
+        return nullptr;
+    }
+    if (lv_obj_check_type(root, &lv_canvas_class)) {
+        return root;
+    }
+
+    const auto child_count = lv_obj_get_child_cnt(root);
+    for (std::uint32_t i = 0; i < child_count; ++i) {
+        if (auto* found = find_first_canvas(lv_obj_get_child(root, i)); found != nullptr) {
+            return found;
+        }
+    }
+    return nullptr;
 }
 }  // namespace
 
@@ -72,7 +91,25 @@ void test_external_scan_flow_demo() {
 
     active = runtime.activate(RouteDescriptor{.route_id = RouteId{"demo.scan"}, .args = {{"title", "Scan QR"}, {"status", "Waiting for host capture command"}}});
     assert(active.has_value());
-    assert(runtime.push_frame(CameraFrame{.width = 64, .height = 64, .stride = 64, .sequence = 3, .pixels = std::vector<std::uint8_t>(64 * 64, 0xaa)}));
+
+    std::vector<std::uint8_t> pixels(8 * 8, 0x10);
+    for (std::uint32_t y = 0; y < 8; ++y) {
+        for (std::uint32_t x = 4; x < 8; ++x) {
+            pixels[static_cast<std::size_t>(y) * 8 + x] = 0xf0;
+        }
+    }
+
+    assert(runtime.push_frame(CameraFrame{.width = 8, .height = 8, .stride = 8, .sequence = 3, .pixels = pixels}));
+    runtime.refresh_now();
+
+    auto* canvas = find_first_canvas(lv_scr_act());
+    assert(canvas != nullptr);
+    const auto left_px = lv_canvas_get_px(canvas, 40, 72);
+    const auto right_px = lv_canvas_get_px(canvas, 176, 72);
+    assert(left_px.ch.red < right_px.ch.red);
+    assert(left_px.ch.green < right_px.ch.green);
+    assert(left_px.ch.blue < right_px.ch.blue);
+
     assert(runtime.patch_screen_data({{"status", "Frame 3 ready for capture"}}));
     assert(runtime.send_input(InputEvent{.key = InputKey::Press}));
     auto capture_action = next_matching(runtime, EventType::ActionInvoked);


### PR DESCRIPTION
## Summary
- render injected camera bytes into an LVGL canvas instead of only showing frame metadata
- copy incoming frame data into screen-owned storage before redraw to keep ownership/lifetime explicit
- validate preview rendering in the host smoke test by asserting canvas pixel brightness changes

## Validation
- -- Configuring done
-- Generating done
-- Build files have been written to: /home/ubuntu/.openclaw/workspace/seedsigner-lvgl/build-subagent
- Consolidate compiler generated dependencies of target lvgl
[ 93%] Built target lvgl
Consolidate compiler generated dependencies of target seedsigner_lvgl
[ 97%] Built target seedsigner_lvgl
Consolidate compiler generated dependencies of target host_sim_demo
Consolidate compiler generated dependencies of target seedsigner_lvgl_tests
[100%] Built target host_sim_demo
[100%] Built target seedsigner_lvgl_tests
- Internal ctest changing into directory: /home/ubuntu/.openclaw/workspace/seedsigner-lvgl/build-subagent
Test project /home/ubuntu/.openclaw/workspace/seedsigner-lvgl/build-subagent
    Start 1: seedsigner_lvgl_tests
1/1 Test #1: seedsigner_lvgl_tests ............   Passed    0.02 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.02 sec
- menu selected=network
menu focus=display
captured frame=1
route=demo.result token=3 flushes=1

Closes #9