### PR TITLE
feat: add first settings selection route

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(seedsigner_lvgl
   src/screens/MenuListScreen.cpp
   src/screens/PlaceholderScreen.cpp
   src/screens/ResultScreen.cpp
+  src/screens/SettingsSelectionScreen.cpp
 )
 
 target_include_directories(seedsigner_lvgl

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Current implementation scope:
 - headless host display integration for smoke validation
 - `UiRuntime` top-level owner with screen registry and outbound event queue scaffolding
 - structured SeedSigner-style menu/list screen with simple top-nav chrome, two-line rows, and accessory/checkmark support for settings-style screens
-- host demo route and smoke tests for placeholder and menu flows
+- first real settings-selection route with title/subtitle/section framing and single-select outbound events
+- host demo route and smoke tests for placeholder, settings, menu, scan, and result flows
 
 Still intentionally out of scope:
 - embedded bring-up
@@ -46,6 +47,8 @@ ctest --test-dir build --output-on-failure
 The initial simulator target is deliberately headless. It uses LVGL with a dummy host display so the runtime, screen lifecycle, draw/flush path, and menu input/event behavior can be exercised in CI and on developer machines without committing yet to SDL or embedded platform glue.
 
 `MenuListScreen` now accepts either simple rows (`id|Label`) or richer structured rows (`id|Label|Secondary text|accessory`). The current accessory shortcuts are `check` and `chevron`, which are enough to start building settings-family and selector-family screens without inventing a new payload format yet.
+
+`SettingsSelectionScreen` is the first concrete consumer of that list model. It adds route-level framing (`title`, `subtitle`, `section_title`) on top of the same row payload and emits `focus_changed` / `setting_selected` events from the `settings_selection` component.
 
 The repo now carries its own LVGL configuration in [`config/lv_conf.h`](config/lv_conf.h), so host builds do not require contributors to copy `lv_conf_template.h` or maintain a machine-local `lv_conf.h`.
 

--- a/docs/discovery/seedsigner-screen-parity-matrix.md
+++ b/docs/discovery/seedsigner-screen-parity-matrix.md
@@ -15,6 +15,7 @@ Implemented in `main` today:
 - `ResultScreen`
 - `CameraPreviewScreen`
 - `PlaceholderScreen` (development stub, not a parity target)
+- `SettingsSelectionScreen` (first real settings-route slice)
 - runtime hooks for input events, outbound screen events, full/patch screen data, and external frame injection
 
 ## Status scale
@@ -49,7 +50,7 @@ Implemented in `main` today:
 | Seed word entry / passphrase entry / coin-flip / dice / numeric-entry keyboards | Data entry / keyboard | Very High | **none** | Reusable keyboard framework, alternate layouts, cursor model, text editing, side soft-buttons | Biggest missing interaction family after simple menus/scan shell. |
 | Transaction review family (`PSBTOverviewScreen`, math/details/finalize) | Transaction review | Very High | **none** | Bitcoin formatting widgets, diagrams, address formatting, review pagination, approval UX | No meaningful parity started. |
 | Seed reveal / backup / transcription / verification custom screens | Sensitive seed management | Very High | **none** | Warning chrome, pagination, QR display, keyboard/input, custom overlays | Large domain still untouched beyond generic primitives. |
-| Settings entry update selection / locale selection | Settings / structured lists | Medium | **partial** via richer `MenuListScreen` rows | Need true single/multi-select semantics, route-specific payload schema, help/footer chrome | Secondary text plus checkmark/chevron accessories now cover the first realistic settings-list shell, but not full settings flow behavior yet. |
+| Settings entry update selection / locale selection | Settings / structured lists | Medium | **partial** via `SettingsSelectionScreen` | Need true multi-select semantics, checkbox variants, route-specific payload schema, help/footer chrome beyond subtitle/section framing | A first real settings route now exists with title/subtitle/section framing, richer rows, single-select focus/selection events, and checkmark/chevron accessory support. It is still a narrow slice rather than full settings-flow parity. |
 | Address explorer lists / address detail export | Tools / structured data views | High | **none** | Fixed-width address rows, pagination, QR display, derivation/fingerprint widgets | Blocked on formatted data components and QR display. |
 
 ## What is genuinely covered now
@@ -62,18 +63,24 @@ Implemented in `main` today:
    - up/down/press/back input handling
    - outbound events for focus change and selection
 
-2. **Host-driven result/info shell**
+2. **First real settings-selection route**
+   - title + subtitle framing
+   - optional section heading
+   - richer rows with current-value/accessory semantics
+   - single-select `setting_selected` outbound action
+
+3. **Host-driven result/info shell**
    - title/body rendering
    - full replace + patch update paths
    - confirm/cancel style event emission
 
-3. **Host-driven camera preview shell**
+4. **Host-driven camera preview shell**
    - external frame ingestion
    - preview metadata updates
    - explicit `needs_data(camera.frame)` handshake
    - capture/cancel event emission
 
-4. **Runtime control surface that matches the external-control architecture**
+5. **Runtime control surface that matches the external-control architecture**
    - `send_input(...)`
    - `set_screen_data(...)`
    - `patch_screen_data(...)`

--- a/examples/host_sim_demo.cpp
+++ b/examples/host_sim_demo.cpp
@@ -8,6 +8,7 @@
 #include "seedsigner_lvgl/screens/CameraPreviewScreen.hpp"
 #include "seedsigner_lvgl/screens/MenuListScreen.hpp"
 #include "seedsigner_lvgl/screens/ResultScreen.hpp"
+#include "seedsigner_lvgl/screens/SettingsSelectionScreen.hpp"
 
 namespace {
 using namespace seedsigner::lvgl;
@@ -27,17 +28,29 @@ int main() {
     runtime.screen_registry().register_route(RouteId{"demo.menu"}, []() -> std::unique_ptr<Screen> { return std::make_unique<MenuListScreen>(); });
     runtime.screen_registry().register_route(RouteId{"demo.scan"}, []() -> std::unique_ptr<Screen> { return std::make_unique<CameraPreviewScreen>(); });
     runtime.screen_registry().register_route(RouteId{"demo.result"}, []() -> std::unique_ptr<Screen> { return std::make_unique<ResultScreen>(); });
+    runtime.screen_registry().register_route(RouteId{"settings.locale"}, []() -> std::unique_ptr<Screen> { return std::make_unique<SettingsSelectionScreen>(); });
+
+    runtime.activate({.route_id = RouteId{"settings.locale"},
+                      .args = {{"title", "Settings"},
+                               {"subtitle", "Language"},
+                               {"section_title", "Display language"},
+                               {"selected_index", "1"},
+                               {"items", "en|English|Use the default Latin font stack\nes|Español|Use accented glyphs in the UI|check\nfr|Français|Preview wider Latin text coverage"}}});
+    runtime.send_input(InputEvent{.key = InputKey::Up});
+    const auto focus = next_matching(runtime, EventType::ActionInvoked);
+    if (!focus || !focus->meta || focus->meta->key != "en") return 5;
+    std::cout << "settings focus=" << focus->meta->key << "\n";
+
+    runtime.send_input(InputEvent{.key = InputKey::Press});
+    const auto setting = next_matching(runtime, EventType::ActionInvoked);
+    if (!setting || setting->action_id != std::optional<std::string>{"setting_selected"} || !setting->meta || setting->meta->key != "en") return 2;
+    std::cout << "settings selected=" << setting->meta->key << "\n";
 
     runtime.activate({.route_id = RouteId{"demo.menu"}, .args = {{"title", "Settings"}, {"items", "network|Network|Configure host bridge|chevron\ndisplay|Persistent display|Keep screen awake while plugged in|check\nscan|Scan QR demo|Open the camera preview shell|chevron"}}});
     runtime.send_input(InputEvent{.key = InputKey::Press});
     const auto menu_action = next_matching(runtime, EventType::ActionInvoked);
-    if (!menu_action || !menu_action->meta || menu_action->meta->key != "network") return 2;
+    if (!menu_action || !menu_action->meta || menu_action->meta->key != "network") return 6;
     std::cout << "menu selected=" << menu_action->meta->key << "\n";
-
-    runtime.send_input(InputEvent{.key = InputKey::Down});
-    const auto focus = next_matching(runtime, EventType::ActionInvoked);
-    if (!focus || !focus->meta || focus->meta->key != "display") return 5;
-    std::cout << "menu focus=" << focus->meta->key << "\n";
 
     runtime.activate({.route_id = RouteId{"demo.scan"}, .args = {{"title", "Camera Preview"}, {"status", "Controller waiting for capture"}}});
     std::vector<std::uint8_t> preview_pixels(96 * 96, 0x18);

--- a/include/seedsigner_lvgl/screens/SettingsSelectionScreen.hpp
+++ b/include/seedsigner_lvgl/screens/SettingsSelectionScreen.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "seedsigner_lvgl/screen/Screen.hpp"
+
+namespace seedsigner::lvgl {
+
+class SettingsSelectionScreen : public Screen {
+public:
+    struct Item {
+        std::string id;
+        std::string label;
+        std::string secondary_text;
+        std::string accessory;
+    };
+
+    void create(const ScreenContext& context, const RouteDescriptor& route) override;
+    void destroy() override;
+    bool handle_input(const InputEvent& input) override;
+    bool set_data(const PropertyMap& data) override;
+
+    std::size_t item_count() const noexcept { return items_.size(); }
+    std::size_t selected_index() const noexcept { return selected_index_; }
+    const std::string& title() const noexcept { return title_; }
+    const std::string& subtitle() const noexcept { return subtitle_; }
+    const std::string& section_title() const noexcept { return section_title_; }
+
+private:
+    static std::vector<Item> parse_items(const PropertyMap& args);
+    static std::size_t parse_selected_index(const PropertyMap& args);
+    static std::string value_or(const PropertyMap& values, const char* key, const char* fallback = "");
+
+    void apply_selection(std::size_t index);
+    void emit_focus_changed(const ScreenContext& context, std::size_t index) const;
+    void emit_item_selected(const ScreenContext& context, std::size_t index) const;
+    const Item* find_item(const lv_obj_t* button, std::size_t* index = nullptr) const noexcept;
+    static void on_item_event(lv_event_t* event);
+
+    ScreenContext context_{};
+    lv_obj_t* container_{nullptr};
+    lv_obj_t* list_{nullptr};
+    lv_obj_t* empty_state_{nullptr};
+    lv_style_t selected_row_style_{};
+    lv_style_t row_style_{};
+    bool styles_initialized_{false};
+    std::string title_;
+    std::string subtitle_;
+    std::string section_title_;
+    std::vector<Item> items_{};
+    std::vector<lv_obj_t*> item_buttons_{};
+    std::size_t selected_index_{0};
+};
+
+}  // namespace seedsigner::lvgl

--- a/src/screens/SettingsSelectionScreen.cpp
+++ b/src/screens/SettingsSelectionScreen.cpp
@@ -1,0 +1,348 @@
+#include "seedsigner_lvgl/screens/SettingsSelectionScreen.hpp"
+
+#include <algorithm>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace seedsigner::lvgl {
+
+namespace {
+
+constexpr const char* kFocusAction = "focus_changed";
+constexpr const char* kSelectAction = "setting_selected";
+constexpr const char* kSettingsComponent = "settings_selection";
+constexpr const char* kTitleArg = "title";
+constexpr const char* kSubtitleArg = "subtitle";
+constexpr const char* kSectionTitleArg = "section_title";
+constexpr const char* kItemsArg = "items";
+constexpr const char* kSelectedIndexArg = "selected_index";
+
+std::string trim(std::string value) {
+    const auto first = value.find_first_not_of(" \t\r\n");
+    if (first == std::string::npos) {
+        return {};
+    }
+
+    const auto last = value.find_last_not_of(" \t\r\n");
+    return value.substr(first, last - first + 1);
+}
+
+const char* accessory_glyph(std::string_view accessory) {
+    if (accessory == "check" || accessory == "checked" || accessory == "selected") {
+        return LV_SYMBOL_OK;
+    }
+    if (accessory == "chevron" || accessory == "next") {
+        return LV_SYMBOL_RIGHT;
+    }
+    if (accessory == "toggle_on") {
+        return LV_SYMBOL_OK " on";
+    }
+    return nullptr;
+}
+
+}  // namespace
+
+void SettingsSelectionScreen::create(const ScreenContext& context, const RouteDescriptor& route) {
+    context_ = context;
+    title_ = value_or(route.args, kTitleArg, "Settings");
+    subtitle_ = value_or(route.args, kSubtitleArg);
+    section_title_ = value_or(route.args, kSectionTitleArg);
+    items_ = parse_items(route.args);
+    selected_index_ = parse_selected_index(route.args);
+    item_buttons_.clear();
+
+    if (!styles_initialized_) {
+        lv_style_init(&row_style_);
+        lv_style_set_radius(&row_style_, 8);
+        lv_style_set_pad_all(&row_style_, 10);
+        lv_style_set_pad_gap(&row_style_, 8);
+        lv_style_set_bg_opa(&row_style_, LV_OPA_TRANSP);
+        lv_style_set_border_width(&row_style_, 1);
+        lv_style_set_border_color(&row_style_, lv_palette_lighten(LV_PALETTE_GREY, 1));
+
+        lv_style_init(&selected_row_style_);
+        lv_style_set_bg_opa(&selected_row_style_, LV_OPA_20);
+        lv_style_set_bg_color(&selected_row_style_, lv_palette_main(LV_PALETTE_BLUE));
+        lv_style_set_border_width(&selected_row_style_, 2);
+        lv_style_set_border_color(&selected_row_style_, lv_palette_main(LV_PALETTE_BLUE));
+        styles_initialized_ = true;
+    }
+
+    container_ = lv_obj_create(context.root);
+    lv_obj_set_size(container_, lv_pct(100), lv_pct(100));
+    lv_obj_set_style_pad_all(container_, 12, 0);
+    lv_obj_set_style_pad_row(container_, 8, 0);
+    lv_obj_set_flex_flow(container_, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(container_, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+
+    auto* title = lv_label_create(container_);
+    lv_obj_set_width(title, lv_pct(100));
+    lv_label_set_text(title, title_.c_str());
+
+    if (!subtitle_.empty()) {
+        auto* subtitle = lv_label_create(container_);
+        lv_obj_set_width(subtitle, lv_pct(100));
+        lv_label_set_long_mode(subtitle, LV_LABEL_LONG_WRAP);
+        lv_obj_set_style_text_opa(subtitle, LV_OPA_70, 0);
+        lv_label_set_text(subtitle, subtitle_.c_str());
+    }
+
+    if (!section_title_.empty()) {
+        auto* section = lv_label_create(container_);
+        lv_obj_set_width(section, lv_pct(100));
+        lv_obj_set_style_text_opa(section, LV_OPA_70, 0);
+        lv_label_set_text(section, section_title_.c_str());
+    }
+
+    list_ = lv_obj_create(container_);
+    lv_obj_set_size(list_, lv_pct(100), lv_pct(100));
+    lv_obj_set_flex_grow(list_, 1);
+    lv_obj_set_scroll_dir(list_, LV_DIR_VER);
+    lv_obj_set_flex_flow(list_, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(list_, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+    lv_obj_set_style_pad_all(list_, 0, 0);
+    lv_obj_set_style_pad_row(list_, 8, 0);
+
+    if (items_.empty()) {
+        empty_state_ = lv_label_create(list_);
+        lv_obj_set_width(empty_state_, lv_pct(100));
+        lv_label_set_long_mode(empty_state_, LV_LABEL_LONG_WRAP);
+        lv_label_set_text(empty_state_, "No settings options provided.");
+        return;
+    }
+
+    if (selected_index_ >= items_.size()) {
+        selected_index_ = 0;
+    }
+
+    for (std::size_t index = 0; index < items_.size(); ++index) {
+        const auto& item = items_[index];
+        auto* button = lv_btn_create(list_);
+        lv_obj_set_width(button, lv_pct(100));
+        lv_obj_set_style_min_height(button, item.secondary_text.empty() ? 46 : 64, 0);
+        lv_obj_set_flex_flow(button, LV_FLEX_FLOW_ROW);
+        lv_obj_set_flex_align(button, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+        lv_obj_add_style(button, &row_style_, LV_PART_MAIN);
+        lv_obj_add_event_cb(button, &SettingsSelectionScreen::on_item_event, LV_EVENT_FOCUSED, this);
+        lv_obj_add_event_cb(button, &SettingsSelectionScreen::on_item_event, LV_EVENT_CLICKED, this);
+
+        auto* text_column = lv_obj_create(button);
+        lv_obj_set_flex_grow(text_column, 1);
+        lv_obj_set_height(text_column, LV_SIZE_CONTENT);
+        lv_obj_set_style_bg_opa(text_column, LV_OPA_TRANSP, 0);
+        lv_obj_set_style_border_width(text_column, 0, 0);
+        lv_obj_set_style_pad_all(text_column, 0, 0);
+        lv_obj_set_style_pad_row(text_column, 2, 0);
+        lv_obj_set_flex_flow(text_column, LV_FLEX_FLOW_COLUMN);
+        lv_obj_clear_flag(text_column, LV_OBJ_FLAG_SCROLLABLE);
+
+        auto* primary = lv_label_create(text_column);
+        lv_obj_set_width(primary, lv_pct(100));
+        lv_label_set_long_mode(primary, LV_LABEL_LONG_DOT);
+        lv_label_set_text(primary, item.label.c_str());
+
+        if (!item.secondary_text.empty()) {
+            auto* secondary = lv_label_create(text_column);
+            lv_obj_set_width(secondary, lv_pct(100));
+            lv_label_set_long_mode(secondary, LV_LABEL_LONG_DOT);
+            lv_obj_set_style_text_opa(secondary, LV_OPA_70, 0);
+            lv_label_set_text(secondary, item.secondary_text.c_str());
+        }
+
+        if (!item.accessory.empty()) {
+            auto* accessory = lv_label_create(button);
+            const char* glyph = accessory_glyph(item.accessory);
+            lv_label_set_text(accessory, glyph != nullptr ? glyph : item.accessory.c_str());
+            lv_obj_set_style_text_align(accessory, LV_TEXT_ALIGN_RIGHT, 0);
+        }
+
+        item_buttons_.push_back(button);
+    }
+
+    apply_selection(selected_index_);
+}
+
+void SettingsSelectionScreen::destroy() {
+    if (container_ != nullptr) {
+        lv_obj_del(container_);
+    }
+
+    container_ = nullptr;
+    list_ = nullptr;
+    empty_state_ = nullptr;
+    item_buttons_.clear();
+    items_.clear();
+    selected_index_ = 0;
+    title_.clear();
+    subtitle_.clear();
+    section_title_.clear();
+    context_ = {};
+}
+
+bool SettingsSelectionScreen::handle_input(const InputEvent& input) {
+    if (items_.empty()) {
+        return false;
+    }
+
+    switch (input.key) {
+    case InputKey::Up:
+        apply_selection(selected_index_ == 0 ? item_buttons_.size() - 1 : selected_index_ - 1);
+        emit_focus_changed(context_, selected_index_);
+        return true;
+    case InputKey::Down:
+        apply_selection((selected_index_ + 1) % item_buttons_.size());
+        emit_focus_changed(context_, selected_index_);
+        return true;
+    case InputKey::Press:
+        emit_item_selected(context_, selected_index_);
+        return true;
+    case InputKey::Back:
+        return context_.emit_cancel(kSettingsComponent);
+    case InputKey::Left:
+    case InputKey::Right:
+        return false;
+    }
+
+    return false;
+}
+
+bool SettingsSelectionScreen::set_data(const PropertyMap& data) {
+    const auto context = context_;
+    destroy();
+    create(context, RouteDescriptor{.route_id = context.route_id, .args = data});
+    return true;
+}
+
+std::vector<SettingsSelectionScreen::Item> SettingsSelectionScreen::parse_items(const PropertyMap& args) {
+    std::vector<Item> items;
+
+    const auto it = args.find(kItemsArg);
+    if (it == args.end() || it->second.empty()) {
+        return items;
+    }
+
+    std::stringstream lines{it->second};
+    std::string line;
+    while (std::getline(lines, line)) {
+        line = trim(line);
+        if (line.empty()) {
+            continue;
+        }
+
+        std::vector<std::string> parts;
+        std::stringstream columns{line};
+        std::string part;
+        while (std::getline(columns, part, '|')) {
+            parts.push_back(trim(part));
+        }
+
+        if (parts.empty() || parts[0].empty()) {
+            continue;
+        }
+
+        Item item{.id = parts[0],
+                  .label = parts.size() >= 2 && !parts[1].empty() ? parts[1] : parts[0],
+                  .secondary_text = parts.size() >= 3 ? parts[2] : std::string{},
+                  .accessory = parts.size() >= 4 ? parts[3] : std::string{}};
+        items.push_back(std::move(item));
+    }
+
+    return items;
+}
+
+std::size_t SettingsSelectionScreen::parse_selected_index(const PropertyMap& args) {
+    const auto it = args.find(kSelectedIndexArg);
+    if (it == args.end() || it->second.empty()) {
+        return 0;
+    }
+
+    try {
+        return static_cast<std::size_t>(std::stoul(it->second));
+    } catch (...) {
+        return 0;
+    }
+}
+
+std::string SettingsSelectionScreen::value_or(const PropertyMap& values, const char* key, const char* fallback) {
+    const auto it = values.find(key);
+    return it == values.end() ? std::string{fallback} : it->second;
+}
+
+void SettingsSelectionScreen::apply_selection(std::size_t index) {
+    if (item_buttons_.empty()) {
+        selected_index_ = 0;
+        return;
+    }
+
+    selected_index_ = std::min(index, item_buttons_.size() - 1);
+    for (std::size_t button_index = 0; button_index < item_buttons_.size(); ++button_index) {
+        auto* button = item_buttons_[button_index];
+        lv_obj_remove_style(button, &selected_row_style_, LV_PART_MAIN);
+        if (button_index == selected_index_) {
+            lv_obj_add_style(button, &selected_row_style_, LV_PART_MAIN);
+            lv_obj_scroll_to_view(button, LV_ANIM_OFF);
+        }
+    }
+}
+
+void SettingsSelectionScreen::emit_focus_changed(const ScreenContext& context, std::size_t index) const {
+    if (index >= items_.size()) {
+        return;
+    }
+
+    context.emit_action(kFocusAction,
+                        kSettingsComponent,
+                        EventValue{static_cast<std::int64_t>(index)},
+                        EventMeta{items_[index].id, std::string{items_[index].label}});
+}
+
+void SettingsSelectionScreen::emit_item_selected(const ScreenContext& context, std::size_t index) const {
+    if (index >= items_.size()) {
+        return;
+    }
+
+    context.emit_action(kSelectAction,
+                        kSettingsComponent,
+                        EventValue{static_cast<std::int64_t>(index)},
+                        EventMeta{items_[index].id, std::string{items_[index].label}});
+}
+
+const SettingsSelectionScreen::Item* SettingsSelectionScreen::find_item(const lv_obj_t* button, std::size_t* index) const noexcept {
+    for (std::size_t item_index = 0; item_index < item_buttons_.size(); ++item_index) {
+        if (item_buttons_[item_index] == button) {
+            if (index != nullptr) {
+                *index = item_index;
+            }
+            return &items_[item_index];
+        }
+    }
+
+    return nullptr;
+}
+
+void SettingsSelectionScreen::on_item_event(lv_event_t* event) {
+    auto* screen = static_cast<SettingsSelectionScreen*>(lv_event_get_user_data(event));
+    if (screen == nullptr) {
+        return;
+    }
+
+    std::size_t index = 0;
+    if (screen->find_item(lv_event_get_target(event), &index) == nullptr) {
+        return;
+    }
+
+    screen->apply_selection(index);
+
+    if (lv_event_get_code(event) == LV_EVENT_FOCUSED) {
+        screen->emit_focus_changed(screen->context_, index);
+        return;
+    }
+
+    if (lv_event_get_code(event) == LV_EVENT_CLICKED) {
+        screen->emit_item_selected(screen->context_, index);
+    }
+}
+
+}  // namespace seedsigner::lvgl

--- a/tests/navigation_runtime_tests.cpp
+++ b/tests/navigation_runtime_tests.cpp
@@ -13,6 +13,7 @@
 
 namespace tests {
 void test_headless_runtime_bootstrap();
+void test_settings_selection_route_demo();
 void test_external_scan_flow_demo();
 }
 
@@ -133,6 +134,7 @@ int main() {
     test_result_screen_emits_configured_actions();
     test_event_queue_overflow_keeps_fifo_order();
     tests::test_headless_runtime_bootstrap();
+    tests::test_settings_selection_route_demo();
     tests::test_external_scan_flow_demo();
     return 0;
 }

--- a/tests/ui_runtime_smoke_test.cpp
+++ b/tests/ui_runtime_smoke_test.cpp
@@ -11,6 +11,7 @@
 #include "seedsigner_lvgl/screens/MenuListScreen.hpp"
 #include "seedsigner_lvgl/screens/PlaceholderScreen.hpp"
 #include "seedsigner_lvgl/screens/ResultScreen.hpp"
+#include "seedsigner_lvgl/screens/SettingsSelectionScreen.hpp"
 
 namespace tests {
 
@@ -34,6 +35,26 @@ std::optional<UiEvent> next_matching(UiRuntime& runtime, EventType type) {
 
 std::unique_ptr<Screen> make_placeholder() {
     return std::make_unique<seedsigner::lvgl::PlaceholderScreen>();
+}
+
+bool label_tree_contains(lv_obj_t* root, const std::string& text) {
+    if (root == nullptr) {
+        return false;
+    }
+    if (lv_obj_check_type(root, &lv_label_class)) {
+        const char* current = lv_label_get_text(root);
+        if (current != nullptr && text == current) {
+            return true;
+        }
+    }
+
+    const auto child_count = lv_obj_get_child_cnt(root);
+    for (std::uint32_t i = 0; i < child_count; ++i) {
+        if (label_tree_contains(lv_obj_get_child(root, i), text)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 lv_obj_t* find_first_canvas(lv_obj_t* root) {
@@ -68,14 +89,61 @@ void test_headless_runtime_bootstrap() {
     assert(runtime.next_event()->type == EventType::ScreenReady);
 }
 
+void test_settings_selection_route_demo() {
+    UiRuntime runtime;
+    assert(runtime.init());
+    assert(runtime.screen_registry().register_route(RouteId{"settings.locale"}, []() -> std::unique_ptr<Screen> { return std::make_unique<seedsigner::lvgl::SettingsSelectionScreen>(); }));
+
+    const auto active = runtime.activate(RouteDescriptor{.route_id = RouteId{"settings.locale"},
+                                                         .args = {{"title", "Settings"},
+                                                                  {"subtitle", "Language"},
+                                                                  {"section_title", "Display language"},
+                                                                  {"selected_index", "1"},
+                                                                  {"items", "en|English|Use the default Latin font stack\nes|Español|Use accented glyphs in the UI|check\nfr|Français|Preview wider Latin text coverage"}}});
+    assert(active.has_value());
+    runtime.tick(16);
+    runtime.refresh_now();
+
+    assert(label_tree_contains(lv_scr_act(), "Settings"));
+    assert(label_tree_contains(lv_scr_act(), "Language"));
+    assert(label_tree_contains(lv_scr_act(), "Display language"));
+
+    runtime.next_event();
+    runtime.next_event();
+    assert(runtime.send_input(InputEvent{.key = InputKey::Up}));
+    auto focus_event = next_matching(runtime, EventType::ActionInvoked);
+    assert(focus_event.has_value() && focus_event->action_id == std::optional<std::string>{"focus_changed"});
+    assert(focus_event->meta.has_value());
+    assert(focus_event->meta->key == "en");
+
+    assert(runtime.send_input(InputEvent{.key = InputKey::Press}));
+    auto select_event = next_matching(runtime, EventType::ActionInvoked);
+    assert(select_event.has_value() && select_event->action_id == std::optional<std::string>{"setting_selected"});
+    assert(select_event->component_id == std::optional<std::string>{"settings_selection"});
+    assert(select_event->meta.has_value());
+    assert(select_event->meta->key == "en");
+
+    assert(runtime.display()->flush_count() > 0);
+}
+
 void test_external_scan_flow_demo() {
     UiRuntime runtime;
     assert(runtime.init());
     assert(runtime.screen_registry().register_route(RouteId{"demo.menu"}, []() -> std::unique_ptr<Screen> { return std::make_unique<seedsigner::lvgl::MenuListScreen>(); }));
     assert(runtime.screen_registry().register_route(RouteId{"demo.scan"}, []() -> std::unique_ptr<Screen> { return std::make_unique<seedsigner::lvgl::CameraPreviewScreen>(); }));
     assert(runtime.screen_registry().register_route(RouteId{"demo.result"}, []() -> std::unique_ptr<Screen> { return std::make_unique<seedsigner::lvgl::ResultScreen>(); }));
+    assert(runtime.screen_registry().register_route(RouteId{"settings.locale"}, []() -> std::unique_ptr<Screen> { return std::make_unique<seedsigner::lvgl::SettingsSelectionScreen>(); }));
 
-    auto active = runtime.activate(RouteDescriptor{.route_id = RouteId{"demo.menu"}, .args = {{"title", "Settings"}, {"items", "network|Network|Configure host bridge|chevron\ndisplay|Persistent display|Keep screen awake while plugged in|check\nback|Back"}}});
+    auto active = runtime.activate(RouteDescriptor{.route_id = RouteId{"settings.locale"}, .args = {{"title", "Settings"}, {"subtitle", "Language"}, {"section_title", "Display language"}, {"selected_index", "1"}, {"items", "en|English|Use the default Latin font stack\nes|Español|Use accented glyphs in the UI|check\nfr|Français|Preview wider Latin text coverage"}}});
+    assert(active.has_value());
+    assert(runtime.send_input(InputEvent{.key = InputKey::Press}));
+    auto locale_action = next_matching(runtime, EventType::ActionInvoked);
+    assert(locale_action.has_value() && locale_action->action_id == std::optional<std::string>{"setting_selected"});
+    assert(locale_action->meta.has_value());
+    assert(locale_action->meta->key == "es");
+
+
+    active = runtime.activate(RouteDescriptor{.route_id = RouteId{"demo.menu"}, .args = {{"title", "Settings"}, {"items", "network|Network|Configure host bridge|chevron\ndisplay|Persistent display|Keep screen awake while plugged in|check\nback|Back"}}});
     assert(active.has_value());
     assert(runtime.send_input(InputEvent{.key = InputKey::Press}));
     auto menu_action = next_matching(runtime, EventType::ActionInvoked);


### PR DESCRIPTION
## Summary
- add a real settings-selection screen with title, subtitle, section framing, richer rows, and single-select events
- wire a locale-style settings route into host demo and smoke coverage
- update parity docs/README for the new settings slice

## Validation
- cmake --build build -j2
- ctest --test-dir build --output-on-failure
- ./build/host_sim_demo