### PR TITLE
Add richer settings selection semantics

### DIFF
--- a/docs/discovery/seedsigner-screen-parity-matrix.md
+++ b/docs/discovery/seedsigner-screen-parity-matrix.md
@@ -50,7 +50,7 @@ Implemented in `main` today:
 | Seed word entry / passphrase entry / coin-flip / dice / numeric-entry keyboards | Data entry / keyboard | Very High | **none** | Reusable keyboard framework, alternate layouts, cursor model, text editing, side soft-buttons | Biggest missing interaction family after simple menus/scan shell. |
 | Transaction review family (`PSBTOverviewScreen`, math/details/finalize) | Transaction review | Very High | **none** | Bitcoin formatting widgets, diagrams, address formatting, review pagination, approval UX | No meaningful parity started. |
 | Seed reveal / backup / transcription / verification custom screens | Sensitive seed management | Very High | **none** | Warning chrome, pagination, QR display, keyboard/input, custom overlays | Large domain still untouched beyond generic primitives. |
-| Settings entry update selection / locale selection | Settings / structured lists | Medium | **partial** via `SettingsSelectionScreen` | Need true multi-select semantics, checkbox variants, route-specific payload schema, help/footer chrome beyond subtitle/section framing | A first real settings route now exists with title/subtitle/section framing, richer rows, single-select focus/selection events, and checkmark/chevron accessory support. It is still a narrow slice rather than full settings-flow parity. |
+| Settings entry update selection / locale selection | Settings / structured lists | Medium | **partial** via `SettingsSelectionScreen` | Still needs global SeedSigner chrome, per-setting widgets beyond lists, and downstream route wiring into real settings definitions | The settings route now supports explicit `single` vs `multi` select semantics, auto checkbox rendering for multi-select rows, host-friendly `current_value` / `current_values` route args, richer action payload strings describing focused/current values, and optional help/footer copy regions. It remains a narrow routed slice rather than full settings-flow parity. |
 | Address explorer lists / address detail export | Tools / structured data views | High | **none** | Fixed-width address rows, pagination, QR display, derivation/fingerprint widgets | Blocked on formatted data components and QR display. |
 
 ## What is genuinely covered now
@@ -67,7 +67,11 @@ Implemented in `main` today:
    - title + subtitle framing
    - optional section heading
    - richer rows with current-value/accessory semantics
-   - single-select `setting_selected` outbound action
+   - explicit `single` vs `multi` selection modes
+   - `current_value` / `current_values` route args for current state
+   - checkbox rendering for multi-select rows
+   - optional help/footer copy regions
+   - single-select and multi-select `setting_selected` outbound action payloads
 
 3. **Host-driven result/info shell**
    - title/body rendering
@@ -130,13 +134,12 @@ Why this next:
 1. Add a **top-nav + standard screen chrome** wrapper
 2. Finish the list-family shell with:
    - optional icon support
-   - explicit single/multi-select semantics
-   - help/footer copy regions
-3. Add **scroll cues / pagination behavior**
-4. Add at least 2 real route implementations using the family:
+   - scroll cues / pagination behavior
+   - tighter SeedSigner visual treatment around the already-landed selection semantics
+3. Add at least 2 real route implementations using the family:
    - main menu
    - settings menu or seed/signer selector
-5. Keep event contracts external-controller-friendly
+4. Keep event contracts external-controller-friendly
 
 ## Planning takeaway
 

--- a/examples/host_sim_demo.cpp
+++ b/examples/host_sim_demo.cpp
@@ -29,22 +29,40 @@ int main() {
     runtime.screen_registry().register_route(RouteId{"demo.scan"}, []() -> std::unique_ptr<Screen> { return std::make_unique<CameraPreviewScreen>(); });
     runtime.screen_registry().register_route(RouteId{"demo.result"}, []() -> std::unique_ptr<Screen> { return std::make_unique<ResultScreen>(); });
     runtime.screen_registry().register_route(RouteId{"settings.locale"}, []() -> std::unique_ptr<Screen> { return std::make_unique<SettingsSelectionScreen>(); });
+    runtime.screen_registry().register_route(RouteId{"settings.features"}, []() -> std::unique_ptr<Screen> { return std::make_unique<SettingsSelectionScreen>(); });
 
     runtime.activate({.route_id = RouteId{"settings.locale"},
                       .args = {{"title", "Settings"},
                                {"subtitle", "Language"},
                                {"section_title", "Display language"},
+                               {"help_text", "Choose one language for the active UI session."},
+                               {"footer_text", "Press to apply. Back to cancel."},
+                               {"selection_mode", "single"},
+                               {"current_value", "es"},
                                {"selected_index", "1"},
-                               {"items", "en|English|Use the default Latin font stack\nes|Español|Use accented glyphs in the UI|check\nfr|Français|Preview wider Latin text coverage"}}});
+                               {"items", "en|English|Use the default Latin font stack\nes|Español|Use accented glyphs in the UI\nfr|Français|Preview wider Latin text coverage"}}});
     runtime.send_input(InputEvent{.key = InputKey::Up});
     const auto focus = next_matching(runtime, EventType::ActionInvoked);
     if (!focus || !focus->meta || focus->meta->key != "en") return 5;
-    std::cout << "settings focus=" << focus->meta->key << "\n";
+    std::cout << "settings focus=" << focus->meta->key << " payload=" << std::get<std::string>(focus->meta->value) << "\n";
 
     runtime.send_input(InputEvent{.key = InputKey::Press});
     const auto setting = next_matching(runtime, EventType::ActionInvoked);
     if (!setting || setting->action_id != std::optional<std::string>{"setting_selected"} || !setting->meta || setting->meta->key != "en") return 2;
-    std::cout << "settings selected=" << setting->meta->key << "\n";
+    std::cout << "settings selected=" << setting->meta->key << " payload=" << std::get<std::string>(setting->meta->value) << "\n";
+
+    runtime.activate({.route_id = RouteId{"settings.features"},
+                      .args = {{"title", "Settings"},
+                               {"subtitle", "Advanced features"},
+                               {"section_title", "Enabled features"},
+                               {"selection_mode", "multi"},
+                               {"current_values", "dire_warnings,compact_seedqr"},
+                               {"selected_index", "1"},
+                               {"items", "dire_warnings|Dire warnings|Require explicit confirm on dangerous flows\ncompact_seedqr|Compact SeedQR|Prefer compact QR exports when possible\npassphrase|Passphrase support|Enable passphrase entry flows"}}});
+    runtime.send_input(InputEvent{.key = InputKey::Press});
+    const auto feature_toggle = next_matching(runtime, EventType::ActionInvoked);
+    if (!feature_toggle || !feature_toggle->meta || feature_toggle->meta->key != "compact_seedqr") return 7;
+    std::cout << "feature toggled=" << feature_toggle->meta->key << " payload=" << std::get<std::string>(feature_toggle->meta->value) << "\n";
 
     runtime.activate({.route_id = RouteId{"demo.menu"}, .args = {{"title", "Settings"}, {"items", "network|Network|Configure host bridge|chevron\ndisplay|Persistent display|Keep screen awake while plugged in|check\nscan|Scan QR demo|Open the camera preview shell|chevron"}}});
     runtime.send_input(InputEvent{.key = InputKey::Press});

--- a/include/seedsigner_lvgl/screens/SettingsSelectionScreen.hpp
+++ b/include/seedsigner_lvgl/screens/SettingsSelectionScreen.hpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "seedsigner_lvgl/screen/Screen.hpp"
@@ -29,13 +30,28 @@ public:
     const std::string& section_title() const noexcept { return section_title_; }
 
 private:
+    enum class SelectionMode {
+        Single,
+        Multi,
+    };
+
     static std::vector<Item> parse_items(const PropertyMap& args);
     static std::size_t parse_selected_index(const PropertyMap& args);
     static std::string value_or(const PropertyMap& values, const char* key, const char* fallback = "");
+    static SelectionMode parse_selection_mode(const PropertyMap& args);
+    static std::vector<std::string> parse_id_list(std::string_view raw);
+    static std::string join_ids(const std::vector<std::string>& ids);
 
     void apply_selection(std::size_t index);
     void emit_focus_changed(const ScreenContext& context, std::size_t index) const;
     void emit_item_selected(const ScreenContext& context, std::size_t index) const;
+    void apply_current_values_from_route(const PropertyMap& args);
+    void toggle_current_value(std::size_t index);
+    bool is_current_value(std::string_view id) const noexcept;
+    std::vector<std::string> current_value_ids() const;
+    std::string payload_for_item(std::size_t index, std::string_view event_name) const;
+    void refresh_item_accessories();
+    const char* accessory_text_for_item(const Item& item) const;
     const Item* find_item(const lv_obj_t* button, std::size_t* index = nullptr) const noexcept;
     static void on_item_event(lv_event_t* event);
 
@@ -43,14 +59,22 @@ private:
     lv_obj_t* container_{nullptr};
     lv_obj_t* list_{nullptr};
     lv_obj_t* empty_state_{nullptr};
+    lv_obj_t* help_label_{nullptr};
+    lv_obj_t* footer_label_{nullptr};
     lv_style_t selected_row_style_{};
     lv_style_t row_style_{};
     bool styles_initialized_{false};
     std::string title_;
     std::string subtitle_;
     std::string section_title_;
+    std::string help_text_;
+    std::string footer_text_;
+    SelectionMode selection_mode_{SelectionMode::Single};
+    std::string current_value_id_;
+    std::unordered_set<std::string> current_value_ids_set_{};
     std::vector<Item> items_{};
     std::vector<lv_obj_t*> item_buttons_{};
+    std::vector<lv_obj_t*> item_accessory_labels_{};
     std::size_t selected_index_{0};
 };
 

--- a/src/screens/SettingsSelectionScreen.cpp
+++ b/src/screens/SettingsSelectionScreen.cpp
@@ -16,8 +16,15 @@ constexpr const char* kSettingsComponent = "settings_selection";
 constexpr const char* kTitleArg = "title";
 constexpr const char* kSubtitleArg = "subtitle";
 constexpr const char* kSectionTitleArg = "section_title";
+constexpr const char* kHelpTextArg = "help_text";
+constexpr const char* kFooterTextArg = "footer_text";
 constexpr const char* kItemsArg = "items";
 constexpr const char* kSelectedIndexArg = "selected_index";
+constexpr const char* kSelectionModeArg = "selection_mode";
+constexpr const char* kCurrentValueArg = "current_value";
+constexpr const char* kCurrentValuesArg = "current_values";
+constexpr const char* kCheckboxChecked = "[x]";
+constexpr const char* kCheckboxUnchecked = "[ ]";
 
 std::string trim(std::string value) {
     const auto first = value.find_first_not_of(" \t\r\n");
@@ -39,6 +46,12 @@ const char* accessory_glyph(std::string_view accessory) {
     if (accessory == "toggle_on") {
         return LV_SYMBOL_OK " on";
     }
+    if (accessory == "checkbox" || accessory == "unchecked") {
+        return kCheckboxUnchecked;
+    }
+    if (accessory == "checkbox_checked") {
+        return kCheckboxChecked;
+    }
     return nullptr;
 }
 
@@ -49,9 +62,14 @@ void SettingsSelectionScreen::create(const ScreenContext& context, const RouteDe
     title_ = value_or(route.args, kTitleArg, "Settings");
     subtitle_ = value_or(route.args, kSubtitleArg);
     section_title_ = value_or(route.args, kSectionTitleArg);
+    help_text_ = value_or(route.args, kHelpTextArg);
+    footer_text_ = value_or(route.args, kFooterTextArg);
+    selection_mode_ = parse_selection_mode(route.args);
     items_ = parse_items(route.args);
     selected_index_ = parse_selected_index(route.args);
+    apply_current_values_from_route(route.args);
     item_buttons_.clear();
+    item_accessory_labels_.clear();
 
     if (!styles_initialized_) {
         lv_style_init(&row_style_);
@@ -97,7 +115,7 @@ void SettingsSelectionScreen::create(const ScreenContext& context, const RouteDe
     }
 
     list_ = lv_obj_create(container_);
-    lv_obj_set_size(list_, lv_pct(100), lv_pct(100));
+    lv_obj_set_size(list_, lv_pct(100), LV_SIZE_CONTENT);
     lv_obj_set_flex_grow(list_, 1);
     lv_obj_set_scroll_dir(list_, LV_DIR_VER);
     lv_obj_set_flex_flow(list_, LV_FLEX_FLOW_COLUMN);
@@ -110,58 +128,72 @@ void SettingsSelectionScreen::create(const ScreenContext& context, const RouteDe
         lv_obj_set_width(empty_state_, lv_pct(100));
         lv_label_set_long_mode(empty_state_, LV_LABEL_LONG_WRAP);
         lv_label_set_text(empty_state_, "No settings options provided.");
-        return;
-    }
-
-    if (selected_index_ >= items_.size()) {
-        selected_index_ = 0;
-    }
-
-    for (std::size_t index = 0; index < items_.size(); ++index) {
-        const auto& item = items_[index];
-        auto* button = lv_btn_create(list_);
-        lv_obj_set_width(button, lv_pct(100));
-        lv_obj_set_style_min_height(button, item.secondary_text.empty() ? 46 : 64, 0);
-        lv_obj_set_flex_flow(button, LV_FLEX_FLOW_ROW);
-        lv_obj_set_flex_align(button, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-        lv_obj_add_style(button, &row_style_, LV_PART_MAIN);
-        lv_obj_add_event_cb(button, &SettingsSelectionScreen::on_item_event, LV_EVENT_FOCUSED, this);
-        lv_obj_add_event_cb(button, &SettingsSelectionScreen::on_item_event, LV_EVENT_CLICKED, this);
-
-        auto* text_column = lv_obj_create(button);
-        lv_obj_set_flex_grow(text_column, 1);
-        lv_obj_set_height(text_column, LV_SIZE_CONTENT);
-        lv_obj_set_style_bg_opa(text_column, LV_OPA_TRANSP, 0);
-        lv_obj_set_style_border_width(text_column, 0, 0);
-        lv_obj_set_style_pad_all(text_column, 0, 0);
-        lv_obj_set_style_pad_row(text_column, 2, 0);
-        lv_obj_set_flex_flow(text_column, LV_FLEX_FLOW_COLUMN);
-        lv_obj_clear_flag(text_column, LV_OBJ_FLAG_SCROLLABLE);
-
-        auto* primary = lv_label_create(text_column);
-        lv_obj_set_width(primary, lv_pct(100));
-        lv_label_set_long_mode(primary, LV_LABEL_LONG_DOT);
-        lv_label_set_text(primary, item.label.c_str());
-
-        if (!item.secondary_text.empty()) {
-            auto* secondary = lv_label_create(text_column);
-            lv_obj_set_width(secondary, lv_pct(100));
-            lv_label_set_long_mode(secondary, LV_LABEL_LONG_DOT);
-            lv_obj_set_style_text_opa(secondary, LV_OPA_70, 0);
-            lv_label_set_text(secondary, item.secondary_text.c_str());
+    } else {
+        if (selected_index_ >= items_.size()) {
+            selected_index_ = 0;
         }
 
-        if (!item.accessory.empty()) {
+        for (std::size_t index = 0; index < items_.size(); ++index) {
+            const auto& item = items_[index];
+            auto* button = lv_btn_create(list_);
+            lv_obj_set_width(button, lv_pct(100));
+            lv_obj_set_style_min_height(button, item.secondary_text.empty() ? 46 : 64, 0);
+            lv_obj_set_flex_flow(button, LV_FLEX_FLOW_ROW);
+            lv_obj_set_flex_align(button, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+            lv_obj_add_style(button, &row_style_, LV_PART_MAIN);
+            lv_obj_add_event_cb(button, &SettingsSelectionScreen::on_item_event, LV_EVENT_FOCUSED, this);
+            lv_obj_add_event_cb(button, &SettingsSelectionScreen::on_item_event, LV_EVENT_CLICKED, this);
+
+            auto* text_column = lv_obj_create(button);
+            lv_obj_set_flex_grow(text_column, 1);
+            lv_obj_set_height(text_column, LV_SIZE_CONTENT);
+            lv_obj_set_style_bg_opa(text_column, LV_OPA_TRANSP, 0);
+            lv_obj_set_style_border_width(text_column, 0, 0);
+            lv_obj_set_style_pad_all(text_column, 0, 0);
+            lv_obj_set_style_pad_row(text_column, 2, 0);
+            lv_obj_set_flex_flow(text_column, LV_FLEX_FLOW_COLUMN);
+            lv_obj_clear_flag(text_column, LV_OBJ_FLAG_SCROLLABLE);
+
+            auto* primary = lv_label_create(text_column);
+            lv_obj_set_width(primary, lv_pct(100));
+            lv_label_set_long_mode(primary, LV_LABEL_LONG_DOT);
+            lv_label_set_text(primary, item.label.c_str());
+
+            if (!item.secondary_text.empty()) {
+                auto* secondary = lv_label_create(text_column);
+                lv_obj_set_width(secondary, lv_pct(100));
+                lv_label_set_long_mode(secondary, LV_LABEL_LONG_DOT);
+                lv_obj_set_style_text_opa(secondary, LV_OPA_70, 0);
+                lv_label_set_text(secondary, item.secondary_text.c_str());
+            }
+
             auto* accessory = lv_label_create(button);
-            const char* glyph = accessory_glyph(item.accessory);
-            lv_label_set_text(accessory, glyph != nullptr ? glyph : item.accessory.c_str());
+            lv_label_set_text(accessory, accessory_text_for_item(item));
             lv_obj_set_style_text_align(accessory, LV_TEXT_ALIGN_RIGHT, 0);
+
+            item_buttons_.push_back(button);
+            item_accessory_labels_.push_back(accessory);
         }
 
-        item_buttons_.push_back(button);
+        apply_selection(selected_index_);
+        refresh_item_accessories();
     }
 
-    apply_selection(selected_index_);
+    if (!help_text_.empty()) {
+        help_label_ = lv_label_create(container_);
+        lv_obj_set_width(help_label_, lv_pct(100));
+        lv_label_set_long_mode(help_label_, LV_LABEL_LONG_WRAP);
+        lv_obj_set_style_text_opa(help_label_, LV_OPA_70, 0);
+        lv_label_set_text(help_label_, help_text_.c_str());
+    }
+
+    if (!footer_text_.empty()) {
+        footer_label_ = lv_label_create(container_);
+        lv_obj_set_width(footer_label_, lv_pct(100));
+        lv_label_set_long_mode(footer_label_, LV_LABEL_LONG_WRAP);
+        lv_obj_set_style_text_opa(footer_label_, LV_OPA_50, 0);
+        lv_label_set_text(footer_label_, footer_text_.c_str());
+    }
 }
 
 void SettingsSelectionScreen::destroy() {
@@ -172,12 +204,20 @@ void SettingsSelectionScreen::destroy() {
     container_ = nullptr;
     list_ = nullptr;
     empty_state_ = nullptr;
+    help_label_ = nullptr;
+    footer_label_ = nullptr;
     item_buttons_.clear();
+    item_accessory_labels_.clear();
     items_.clear();
     selected_index_ = 0;
     title_.clear();
     subtitle_.clear();
     section_title_.clear();
+    help_text_.clear();
+    footer_text_.clear();
+    current_value_id_.clear();
+    current_value_ids_set_.clear();
+    selection_mode_ = SelectionMode::Single;
     context_ = {};
 }
 
@@ -196,6 +236,8 @@ bool SettingsSelectionScreen::handle_input(const InputEvent& input) {
         emit_focus_changed(context_, selected_index_);
         return true;
     case InputKey::Press:
+        toggle_current_value(selected_index_);
+        refresh_item_accessories();
         emit_item_selected(context_, selected_index_);
         return true;
     case InputKey::Back:
@@ -270,6 +312,61 @@ std::string SettingsSelectionScreen::value_or(const PropertyMap& values, const c
     return it == values.end() ? std::string{fallback} : it->second;
 }
 
+SettingsSelectionScreen::SelectionMode SettingsSelectionScreen::parse_selection_mode(const PropertyMap& args) {
+    const auto raw = value_or(args, kSelectionModeArg, "single");
+    return raw == "multi" ? SelectionMode::Multi : SelectionMode::Single;
+}
+
+std::vector<std::string> SettingsSelectionScreen::parse_id_list(std::string_view raw) {
+    std::vector<std::string> values;
+    std::string current;
+    for (char ch : raw) {
+        if (ch == ',' || ch == '\n' || ch == ';') {
+            auto trimmed = trim(current);
+            if (!trimmed.empty()) {
+                values.push_back(std::move(trimmed));
+            }
+            current.clear();
+            continue;
+        }
+        current.push_back(ch);
+    }
+
+    auto trimmed = trim(current);
+    if (!trimmed.empty()) {
+        values.push_back(std::move(trimmed));
+    }
+    return values;
+}
+
+std::string SettingsSelectionScreen::join_ids(const std::vector<std::string>& ids) {
+    std::string joined;
+    for (std::size_t i = 0; i < ids.size(); ++i) {
+        if (i != 0) {
+            joined += ',';
+        }
+        joined += ids[i];
+    }
+    return joined;
+}
+
+void SettingsSelectionScreen::apply_current_values_from_route(const PropertyMap& args) {
+    current_value_id_.clear();
+    current_value_ids_set_.clear();
+
+    if (selection_mode_ == SelectionMode::Multi) {
+        for (const auto& id : parse_id_list(value_or(args, kCurrentValuesArg))) {
+            current_value_ids_set_.insert(id);
+        }
+        return;
+    }
+
+    current_value_id_ = value_or(args, kCurrentValueArg);
+    if (current_value_id_.empty() && selected_index_ < items_.size()) {
+        current_value_id_ = items_[selected_index_].id;
+    }
+}
+
 void SettingsSelectionScreen::apply_selection(std::size_t index) {
     if (item_buttons_.empty()) {
         selected_index_ = 0;
@@ -295,7 +392,7 @@ void SettingsSelectionScreen::emit_focus_changed(const ScreenContext& context, s
     context.emit_action(kFocusAction,
                         kSettingsComponent,
                         EventValue{static_cast<std::int64_t>(index)},
-                        EventMeta{items_[index].id, std::string{items_[index].label}});
+                        EventMeta{items_[index].id, payload_for_item(index, "focus")});
 }
 
 void SettingsSelectionScreen::emit_item_selected(const ScreenContext& context, std::size_t index) const {
@@ -306,7 +403,99 @@ void SettingsSelectionScreen::emit_item_selected(const ScreenContext& context, s
     context.emit_action(kSelectAction,
                         kSettingsComponent,
                         EventValue{static_cast<std::int64_t>(index)},
-                        EventMeta{items_[index].id, std::string{items_[index].label}});
+                        EventMeta{items_[index].id, payload_for_item(index, "select")});
+}
+
+void SettingsSelectionScreen::toggle_current_value(std::size_t index) {
+    if (index >= items_.size()) {
+        return;
+    }
+
+    const auto& id = items_[index].id;
+    if (selection_mode_ == SelectionMode::Multi) {
+        if (current_value_ids_set_.count(id) != 0U) {
+            current_value_ids_set_.erase(id);
+        } else {
+            current_value_ids_set_.insert(id);
+        }
+        return;
+    }
+
+    current_value_id_ = id;
+}
+
+bool SettingsSelectionScreen::is_current_value(std::string_view id) const noexcept {
+    if (selection_mode_ == SelectionMode::Multi) {
+        return current_value_ids_set_.count(std::string{id}) != 0U;
+    }
+    return current_value_id_ == id;
+}
+
+std::vector<std::string> SettingsSelectionScreen::current_value_ids() const {
+    if (selection_mode_ == SelectionMode::Multi) {
+        std::vector<std::string> ids;
+        ids.reserve(current_value_ids_set_.size());
+        for (const auto& item : items_) {
+            if (current_value_ids_set_.count(item.id) != 0U) {
+                ids.push_back(item.id);
+            }
+        }
+        return ids;
+    }
+
+    if (current_value_id_.empty()) {
+        return {};
+    }
+    return {current_value_id_};
+}
+
+std::string SettingsSelectionScreen::payload_for_item(std::size_t index, std::string_view event_name) const {
+    const auto current_ids = current_value_ids();
+    const auto& item = items_[index];
+    std::string payload;
+    payload += "event=";
+    payload += event_name;
+    payload += ";mode=";
+    payload += selection_mode_ == SelectionMode::Multi ? "multi" : "single";
+    payload += ";index=";
+    payload += std::to_string(index);
+    payload += ";id=";
+    payload += item.id;
+    payload += ";label=";
+    payload += item.label;
+    payload += ";is_current=";
+    payload += is_current_value(item.id) ? "true" : "false";
+    payload += ";current_value=";
+    payload += selection_mode_ == SelectionMode::Single ? current_value_id_ : std::string{};
+    payload += ";current_values=";
+    payload += join_ids(current_ids);
+    return payload;
+}
+
+void SettingsSelectionScreen::refresh_item_accessories() {
+    for (std::size_t index = 0; index < items_.size() && index < item_accessory_labels_.size(); ++index) {
+        if (item_accessory_labels_[index] == nullptr) {
+            continue;
+        }
+        lv_label_set_text(item_accessory_labels_[index], accessory_text_for_item(items_[index]));
+    }
+}
+
+const char* SettingsSelectionScreen::accessory_text_for_item(const Item& item) const {
+    if (selection_mode_ == SelectionMode::Multi) {
+        return is_current_value(item.id) ? kCheckboxChecked : kCheckboxUnchecked;
+    }
+
+    if (is_current_value(item.id)) {
+        return LV_SYMBOL_OK;
+    }
+
+    if (item.accessory.empty()) {
+        return "";
+    }
+
+    const char* glyph = accessory_glyph(item.accessory);
+    return glyph != nullptr ? glyph : item.accessory.c_str();
 }
 
 const SettingsSelectionScreen::Item* SettingsSelectionScreen::find_item(const lv_obj_t* button, std::size_t* index) const noexcept {
@@ -341,6 +530,8 @@ void SettingsSelectionScreen::on_item_event(lv_event_t* event) {
     }
 
     if (lv_event_get_code(event) == LV_EVENT_CLICKED) {
+        screen->toggle_current_value(index);
+        screen->refresh_item_accessories();
         screen->emit_item_selected(screen->context_, index);
     }
 }

--- a/tests/navigation_runtime_tests.cpp
+++ b/tests/navigation_runtime_tests.cpp
@@ -14,6 +14,7 @@
 namespace tests {
 void test_headless_runtime_bootstrap();
 void test_settings_selection_route_demo();
+void test_settings_selection_multi_select_demo();
 void test_external_scan_flow_demo();
 }
 
@@ -135,6 +136,7 @@ int main() {
     test_event_queue_overflow_keeps_fifo_order();
     tests::test_headless_runtime_bootstrap();
     tests::test_settings_selection_route_demo();
+    tests::test_settings_selection_multi_select_demo();
     tests::test_external_scan_flow_demo();
     return 0;
 }

--- a/tests/ui_runtime_smoke_test.cpp
+++ b/tests/ui_runtime_smoke_test.cpp
@@ -98,8 +98,12 @@ void test_settings_selection_route_demo() {
                                                          .args = {{"title", "Settings"},
                                                                   {"subtitle", "Language"},
                                                                   {"section_title", "Display language"},
+                                                                  {"help_text", "Choose one language for the active UI session."},
+                                                                  {"footer_text", "Press to apply. Back to cancel."},
+                                                                  {"selection_mode", "single"},
+                                                                  {"current_value", "es"},
                                                                   {"selected_index", "1"},
-                                                                  {"items", "en|English|Use the default Latin font stack\nes|Español|Use accented glyphs in the UI|check\nfr|Français|Preview wider Latin text coverage"}}});
+                                                                  {"items", "en|English|Use the default Latin font stack\nes|Español|Use accented glyphs in the UI\nfr|Français|Preview wider Latin text coverage"}}});
     assert(active.has_value());
     runtime.tick(16);
     runtime.refresh_now();
@@ -107,6 +111,8 @@ void test_settings_selection_route_demo() {
     assert(label_tree_contains(lv_scr_act(), "Settings"));
     assert(label_tree_contains(lv_scr_act(), "Language"));
     assert(label_tree_contains(lv_scr_act(), "Display language"));
+    assert(label_tree_contains(lv_scr_act(), "Choose one language for the active UI session."));
+    assert(label_tree_contains(lv_scr_act(), "Press to apply. Back to cancel."));
 
     runtime.next_event();
     runtime.next_event();
@@ -115,6 +121,8 @@ void test_settings_selection_route_demo() {
     assert(focus_event.has_value() && focus_event->action_id == std::optional<std::string>{"focus_changed"});
     assert(focus_event->meta.has_value());
     assert(focus_event->meta->key == "en");
+    assert(std::get<std::string>(focus_event->meta->value).find("mode=single") != std::string::npos);
+    assert(std::get<std::string>(focus_event->meta->value).find("current_value=es") != std::string::npos);
 
     assert(runtime.send_input(InputEvent{.key = InputKey::Press}));
     auto select_event = next_matching(runtime, EventType::ActionInvoked);
@@ -122,8 +130,50 @@ void test_settings_selection_route_demo() {
     assert(select_event->component_id == std::optional<std::string>{"settings_selection"});
     assert(select_event->meta.has_value());
     assert(select_event->meta->key == "en");
+    assert(std::get<std::string>(select_event->meta->value).find("current_value=en") != std::string::npos);
+    assert(std::get<std::int64_t>(*select_event->value) == 0);
 
     assert(runtime.display()->flush_count() > 0);
+}
+
+void test_settings_selection_multi_select_demo() {
+    UiRuntime runtime;
+    assert(runtime.init());
+    assert(runtime.screen_registry().register_route(RouteId{"settings.features"}, []() -> std::unique_ptr<Screen> { return std::make_unique<seedsigner::lvgl::SettingsSelectionScreen>(); }));
+
+    const auto active = runtime.activate(RouteDescriptor{.route_id = RouteId{"settings.features"},
+                                                         .args = {{"title", "Settings"},
+                                                                  {"subtitle", "Advanced features"},
+                                                                  {"section_title", "Enabled features"},
+                                                                  {"selection_mode", "multi"},
+                                                                  {"current_values", "dire_warnings,compact_seedqr"},
+                                                                  {"selected_index", "1"},
+                                                                  {"items", "dire_warnings|Dire warnings|Require explicit confirm on dangerous flows\ncompact_seedqr|Compact SeedQR|Prefer compact QR exports when possible\npassphrase|Passphrase support|Enable passphrase entry flows"}}});
+    assert(active.has_value());
+
+    runtime.next_event();
+    runtime.next_event();
+    assert(runtime.send_input(InputEvent{.key = InputKey::Press}));
+    auto toggle_off = next_matching(runtime, EventType::ActionInvoked);
+    assert(toggle_off.has_value());
+    assert(toggle_off->meta.has_value());
+    assert(toggle_off->meta->key == "compact_seedqr");
+    assert(std::get<std::string>(toggle_off->meta->value).find("mode=multi") != std::string::npos);
+    assert(std::get<std::string>(toggle_off->meta->value).find("current_values=dire_warnings") != std::string::npos);
+
+    assert(runtime.send_input(InputEvent{.key = InputKey::Down}));
+    auto focus_event = next_matching(runtime, EventType::ActionInvoked);
+    assert(focus_event.has_value());
+    assert(focus_event->meta.has_value());
+    assert(focus_event->meta->key == "passphrase");
+    assert(std::get<std::string>(focus_event->meta->value).find("current_values=dire_warnings") != std::string::npos);
+
+    assert(runtime.send_input(InputEvent{.key = InputKey::Press}));
+    auto toggle_on = next_matching(runtime, EventType::ActionInvoked);
+    assert(toggle_on.has_value());
+    assert(toggle_on->meta.has_value());
+    assert(toggle_on->meta->key == "passphrase");
+    assert(std::get<std::string>(toggle_on->meta->value).find("current_values=dire_warnings,passphrase") != std::string::npos);
 }
 
 void test_external_scan_flow_demo() {
@@ -134,14 +184,21 @@ void test_external_scan_flow_demo() {
     assert(runtime.screen_registry().register_route(RouteId{"demo.result"}, []() -> std::unique_ptr<Screen> { return std::make_unique<seedsigner::lvgl::ResultScreen>(); }));
     assert(runtime.screen_registry().register_route(RouteId{"settings.locale"}, []() -> std::unique_ptr<Screen> { return std::make_unique<seedsigner::lvgl::SettingsSelectionScreen>(); }));
 
-    auto active = runtime.activate(RouteDescriptor{.route_id = RouteId{"settings.locale"}, .args = {{"title", "Settings"}, {"subtitle", "Language"}, {"section_title", "Display language"}, {"selected_index", "1"}, {"items", "en|English|Use the default Latin font stack\nes|Español|Use accented glyphs in the UI|check\nfr|Français|Preview wider Latin text coverage"}}});
+    auto active = runtime.activate(RouteDescriptor{.route_id = RouteId{"settings.locale"},
+                                                   .args = {{"title", "Settings"},
+                                                            {"subtitle", "Language"},
+                                                            {"section_title", "Display language"},
+                                                            {"selection_mode", "single"},
+                                                            {"current_value", "es"},
+                                                            {"selected_index", "1"},
+                                                            {"items", "en|English|Use the default Latin font stack\nes|Español|Use accented glyphs in the UI\nfr|Français|Preview wider Latin text coverage"}}});
     assert(active.has_value());
     assert(runtime.send_input(InputEvent{.key = InputKey::Press}));
     auto locale_action = next_matching(runtime, EventType::ActionInvoked);
     assert(locale_action.has_value() && locale_action->action_id == std::optional<std::string>{"setting_selected"});
     assert(locale_action->meta.has_value());
     assert(locale_action->meta->key == "es");
-
+    assert(std::get<std::string>(locale_action->meta->value).find("current_value=es") != std::string::npos);
 
     active = runtime.activate(RouteDescriptor{.route_id = RouteId{"demo.menu"}, .args = {{"title", "Settings"}, {"items", "network|Network|Configure host bridge|chevron\ndisplay|Persistent display|Keep screen awake while plugged in|check\nback|Back"}}});
     assert(active.has_value());


### PR DESCRIPTION
## Summary
- extend `SettingsSelectionScreen` with explicit `single` vs `multi` selection semantics
- add host-facing `current_value` / `current_values` args, richer selection payload strings, and optional help/footer regions
- cover the new semantics in smoke tests and refresh the parity matrix/demo

## Validation
- `cmake -S . -B build-subagent`
- `cmake --build build-subagent -j2`
- `ctest --test-dir build-subagent --output-on-failure`
- `./build-subagent/host_sim_demo`

## Notes
This intentionally stays inside the routed settings slice and avoids pulling in global SeedSigner chrome work.
