### PR TITLE
feat(theme): A4 — Dynamic theme support with optional light mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(seedsigner_lvgl
   src/screens/StartupSplashScreen.cpp
   src/screens/ScreensaverScreen.cpp
   src/platform/FramebufferCapture.cpp
+  src/visual/SeedSignerTheme.cpp
   src/assets/icons.c
 )
 

--- a/include/seedsigner_lvgl/visual/SeedSignerTheme.hpp
+++ b/include/seedsigner_lvgl/visual/SeedSignerTheme.hpp
@@ -4,110 +4,152 @@
 
 namespace seedsigner::lvgl::theme {
 
-// SeedSigner color palette
-namespace colors {
-    // Background and surfaces
-    static const lv_color_t BLACK          = lv_color_hex(0x000000);
-    static const lv_color_t SURFACE_DARK   = lv_color_hex(0x1a1a1a);   // Main background
-    static const lv_color_t SURFACE_MEDIUM = lv_color_hex(0x222222);   // Cards, buttons
-    static const lv_color_t SURFACE_LIGHT  = lv_color_hex(0x2a2a2a);   // Pressed states
-    static const lv_color_t SURFACE_DISABLED = lv_color_hex(0x111111); // Disabled controls
-    
+// ---------------------------------------------------------------------------
+// Runtime-swappable theme palette
+// ---------------------------------------------------------------------------
+
+enum class ThemeVariant { Dark, Light };
+
+struct ThemeColors {
+    // Backgrounds & surfaces
+    lv_color_t BLACK;
+    lv_color_t SURFACE_DARK;
+    lv_color_t SURFACE_MEDIUM;
+    lv_color_t SURFACE_LIGHT;
+    lv_color_t SURFACE_DISABLED;
+
     // Primary accent (Bitcoin orange)
-    static const lv_color_t PRIMARY        = lv_color_hex(0xFF9900);
-    static const lv_color_t PRIMARY_LIGHT  = lv_color_hex(0xFFB340);
-    static const lv_color_t PRIMARY_DARK   = lv_color_hex(0xCC7A00);
-    
+    lv_color_t PRIMARY;
+    lv_color_t PRIMARY_LIGHT;
+    lv_color_t PRIMARY_DARK;
+
     // Text
-    static const lv_color_t TEXT_PRIMARY   = lv_color_hex(0xFFFFFF);
-    static const lv_color_t TEXT_SECONDARY = lv_color_hex(0xAAAAAA);
-    static const lv_color_t TEXT_DISABLED  = lv_color_hex(0x555555); // Darker for better contrast on dark surfaces
-    
-    // Semantic colors
-    static const lv_color_t SUCCESS        = lv_color_hex(0x00AA00);
-    static const lv_color_t WARNING        = lv_color_hex(0xFFAA00);
-    static const lv_color_t ERROR          = lv_color_hex(0xFF3333);
-    static const lv_color_t INFO           = lv_color_hex(0x3399FF);
-    
-    // Borders and separators
-    static const lv_color_t BORDER         = lv_color_hex(0x333333);
-    static const lv_color_t DIVIDER        = lv_color_hex(0x444444);
-    
-    // Special purpose
-    static const lv_color_t QR_BACKGROUND  = lv_color_hex(0xFFFFFF);  // White for QR contrast
-    static const lv_color_t QR_FOREGROUND  = lv_color_hex(0x000000);  // Black for QR modules
+    lv_color_t TEXT_PRIMARY;
+    lv_color_t TEXT_SECONDARY;
+    lv_color_t TEXT_DISABLED;
+
+    // Semantic
+    lv_color_t SUCCESS;
+    lv_color_t WARNING;
+    lv_color_t ERROR;
+    lv_color_t INFO;
+
+    // Borders & separators
+    lv_color_t BORDER;
+    lv_color_t DIVIDER;
+
+    // QR
+    lv_color_t QR_BACKGROUND;
+    lv_color_t QR_FOREGROUND;
+};
+
+// Pre-built palettes (defined in SeedSignerTheme.cpp)
+extern const ThemeColors DarkPalette;
+extern const ThemeColors LightPalette;
+
+// Accessor / setter
+const ThemeColors& active_theme();
+void set_theme(ThemeVariant variant);
+ThemeVariant current_theme_variant();
+
+// Legacy namespace kept as compile-time aliases (matches DarkPalette exactly).
+// New code should prefer active_theme().
+namespace colors {
+    static const lv_color_t BLACK            = lv_color_hex(0x000000);
+    static const lv_color_t SURFACE_DARK     = lv_color_hex(0x1a1a1a);
+    static const lv_color_t SURFACE_MEDIUM   = lv_color_hex(0x222222);
+    static const lv_color_t SURFACE_LIGHT    = lv_color_hex(0x2a2a2a);
+    static const lv_color_t SURFACE_DISABLED = lv_color_hex(0x111111);
+    static const lv_color_t PRIMARY          = lv_color_hex(0xFF9900);
+    static const lv_color_t PRIMARY_LIGHT    = lv_color_hex(0xFFB340);
+    static const lv_color_t PRIMARY_DARK     = lv_color_hex(0xCC7A00);
+    static const lv_color_t TEXT_PRIMARY     = lv_color_hex(0xFFFFFF);
+    static const lv_color_t TEXT_SECONDARY   = lv_color_hex(0xAAAAAA);
+    static const lv_color_t TEXT_DISABLED    = lv_color_hex(0x555555);
+    static const lv_color_t SUCCESS          = lv_color_hex(0x00AA00);
+    static const lv_color_t WARNING          = lv_color_hex(0xFFAA00);
+    static const lv_color_t ERROR            = lv_color_hex(0xFF3333);
+    static const lv_color_t INFO             = lv_color_hex(0x3399FF);
+    static const lv_color_t BORDER           = lv_color_hex(0x333333);
+    static const lv_color_t DIVIDER          = lv_color_hex(0x444444);
+    static const lv_color_t QR_BACKGROUND    = lv_color_hex(0xFFFFFF);
+    static const lv_color_t QR_FOREGROUND    = lv_color_hex(0x000000);
 }
 
 // Typography constants
 namespace typography {
-    // Note: Only lv_font_montserrat_14 is currently available in the build
-    constexpr const lv_font_t* TITLE    = &lv_font_montserrat_14;
-    constexpr const lv_font_t* BODY     = &lv_font_montserrat_14;
-    constexpr const lv_font_t* CAPTION  = &lv_font_montserrat_14;
-    constexpr const lv_font_t* MONO     = &lv_font_montserrat_14;  // TODO: Get monospace font
+    constexpr const lv_font_t* TITLE   = &lv_font_montserrat_14;
+    constexpr const lv_font_t* BODY    = &lv_font_montserrat_14;
+    constexpr const lv_font_t* CAPTION = &lv_font_montserrat_14;
+    constexpr const lv_font_t* MONO    = &lv_font_montserrat_14;
 }
 
 // Spacing and sizing
 namespace spacing {
-    constexpr lv_coord_t SCREEN_PADDING = 8;
-    constexpr lv_coord_t COMPONENT_PADDING = 6;
-    constexpr lv_coord_t BUTTON_HEIGHT = 40;
-    constexpr lv_coord_t BUTTON_RADIUS = 4;
-    constexpr lv_coord_t TOPBAR_HEIGHT = 44;
-    constexpr lv_coord_t ROW_RADIUS = 4;
-    constexpr lv_coord_t ROW_PAD = 8;
-    constexpr lv_coord_t ROW_GAP = 6;
-    constexpr lv_coord_t CHIP_RADIUS = 4;
-    constexpr lv_coord_t CHIP_MARGIN = 4;
-    constexpr lv_coord_t CHIP_HEIGHT = 36;
+    constexpr lv_coord_t SCREEN_PADDING     = 8;
+    constexpr lv_coord_t COMPONENT_PADDING  = 6;
+    constexpr lv_coord_t BUTTON_HEIGHT      = 40;
+    constexpr lv_coord_t BUTTON_RADIUS      = 4;
+    constexpr lv_coord_t TOPBAR_HEIGHT      = 44;
+    constexpr lv_coord_t ROW_RADIUS         = 4;
+    constexpr lv_coord_t ROW_PAD            = 8;
+    constexpr lv_coord_t ROW_GAP            = 6;
+    constexpr lv_coord_t CHIP_RADIUS        = 4;
+    constexpr lv_coord_t CHIP_MARGIN        = 4;
+    constexpr lv_coord_t CHIP_HEIGHT        = 36;
 }
 
-// Style helpers
+// ---------------------------------------------------------------------------
+// Style helpers — now read from active_theme()
+// ---------------------------------------------------------------------------
+
 inline void apply_topbar_style(lv_obj_t* obj) {
-    lv_obj_set_style_bg_color(obj, colors::SURFACE_DARK, 0);
+    auto& t = active_theme();
+    lv_obj_set_style_bg_color(obj, t.SURFACE_DARK, 0);
     lv_obj_set_style_bg_opa(obj, LV_OPA_COVER, 0);
     lv_obj_set_style_border_width(obj, 0, 0);
     lv_obj_set_style_pad_all(obj, spacing::COMPONENT_PADDING, 0);
 }
 
 inline void apply_button_style(lv_obj_t* btn, bool is_primary = false) {
+    auto& t = active_theme();
     lv_obj_set_style_radius(btn, spacing::BUTTON_RADIUS, 0);
     lv_obj_set_style_bg_opa(btn, LV_OPA_COVER, 0);
-    lv_obj_set_style_bg_color(btn, is_primary ? colors::PRIMARY : colors::SURFACE_MEDIUM, 0);
-    lv_obj_set_style_bg_color(btn, is_primary ? colors::PRIMARY_DARK : colors::SURFACE_LIGHT, LV_STATE_PRESSED);
-    lv_obj_set_style_bg_color(btn, colors::SURFACE_DISABLED, LV_STATE_DISABLED);
-    lv_obj_set_style_text_color(btn, colors::TEXT_PRIMARY, 0);
-    lv_obj_set_style_text_color(btn, colors::TEXT_PRIMARY, LV_STATE_PRESSED);
-    lv_obj_set_style_text_color(btn, colors::TEXT_DISABLED, LV_STATE_DISABLED);
+    lv_obj_set_style_bg_color(btn, is_primary ? t.PRIMARY : t.SURFACE_MEDIUM, 0);
+    lv_obj_set_style_bg_color(btn, is_primary ? t.PRIMARY_DARK : t.SURFACE_LIGHT, LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(btn, t.SURFACE_DISABLED, LV_STATE_DISABLED);
+    lv_obj_set_style_text_color(btn, t.TEXT_PRIMARY, 0);
+    lv_obj_set_style_text_color(btn, t.TEXT_PRIMARY, LV_STATE_PRESSED);
+    lv_obj_set_style_text_color(btn, t.TEXT_DISABLED, LV_STATE_DISABLED);
     lv_obj_set_style_border_width(btn, 1, 0);
-    lv_obj_set_style_border_color(btn, colors::BORDER, 0);
-    lv_obj_set_style_border_color(btn, is_primary ? colors::PRIMARY_LIGHT : colors::PRIMARY, LV_STATE_PRESSED);
-    lv_obj_set_style_border_color(btn, colors::DIVIDER, LV_STATE_DISABLED);
+    lv_obj_set_style_border_color(btn, t.BORDER, 0);
+    lv_obj_set_style_border_color(btn, is_primary ? t.PRIMARY_LIGHT : t.PRIMARY, LV_STATE_PRESSED);
+    lv_obj_set_style_border_color(btn, t.DIVIDER, LV_STATE_DISABLED);
     lv_obj_set_style_shadow_width(btn, 0, 0);
-    // Stronger press feedback: bigger shadow + visible translate
     lv_obj_set_style_shadow_width(btn, 16, LV_STATE_PRESSED);
     lv_obj_set_style_shadow_spread(btn, 2, LV_STATE_PRESSED);
-    lv_obj_set_style_shadow_color(btn, is_primary ? colors::PRIMARY : colors::BLACK, LV_STATE_PRESSED);
+    lv_obj_set_style_shadow_color(btn, is_primary ? t.PRIMARY : t.BLACK, LV_STATE_PRESSED);
     lv_obj_set_style_shadow_opa(btn, LV_OPA_50, LV_STATE_PRESSED);
     lv_obj_set_style_translate_y(btn, 2, LV_STATE_PRESSED);
     lv_obj_set_style_opa(btn, LV_OPA_50, LV_STATE_DISABLED);
-    // Focus ring for focused (non-pressed) buttons
     lv_obj_set_style_outline_width(btn, 2, LV_STATE_FOCUSED);
     lv_obj_set_style_outline_pad(btn, 1, LV_STATE_FOCUSED);
-    lv_obj_set_style_outline_color(btn, colors::PRIMARY, LV_STATE_FOCUSED);
+    lv_obj_set_style_outline_color(btn, t.PRIMARY, LV_STATE_FOCUSED);
 }
 
 inline void apply_card_style(lv_obj_t* card) {
-    lv_obj_set_style_bg_color(card, colors::SURFACE_MEDIUM, 0);
+    auto& t = active_theme();
+    lv_obj_set_style_bg_color(card, t.SURFACE_MEDIUM, 0);
     lv_obj_set_style_bg_opa(card, LV_OPA_COVER, 0);
     lv_obj_set_style_radius(card, spacing::BUTTON_RADIUS, 0);
-    lv_obj_set_style_border_color(card, colors::BORDER, 0);
+    lv_obj_set_style_border_color(card, t.BORDER, 0);
     lv_obj_set_style_border_width(card, 1, 0);
     lv_obj_set_style_pad_all(card, spacing::COMPONENT_PADDING, 0);
 }
 
 inline void apply_warning_style(lv_obj_t* container, lv_color_t severity_color) {
-    lv_obj_set_style_bg_color(container, colors::SURFACE_MEDIUM, 0);
+    auto& t = active_theme();
+    lv_obj_set_style_bg_color(container, t.SURFACE_MEDIUM, 0);
     lv_obj_set_style_bg_opa(container, LV_OPA_COVER, 0);
     lv_obj_set_style_border_color(container, severity_color, 0);
     lv_obj_set_style_border_width(container, 3, 0);
@@ -116,9 +158,10 @@ inline void apply_warning_style(lv_obj_t* container, lv_color_t severity_color) 
 }
 
 inline void apply_qr_surface_style(lv_obj_t* qr_surface) {
-    lv_obj_set_style_bg_color(qr_surface, colors::QR_BACKGROUND, 0);
+    auto& t = active_theme();
+    lv_obj_set_style_bg_color(qr_surface, t.QR_BACKGROUND, 0);
     lv_obj_set_style_bg_opa(qr_surface, LV_OPA_COVER, 0);
-    lv_obj_set_style_border_color(qr_surface, colors::BORDER, 0);
+    lv_obj_set_style_border_color(qr_surface, t.BORDER, 0);
     lv_obj_set_style_border_width(qr_surface, 2, 0);
     lv_obj_set_style_radius(qr_surface, spacing::BUTTON_RADIUS, 0);
     lv_obj_set_style_pad_all(qr_surface, spacing::COMPONENT_PADDING, 0);

--- a/src/components/TopNavBar.cpp
+++ b/src/components/TopNavBar.cpp
@@ -113,9 +113,9 @@ void TopNavBar::create_widgets() {
         lv_obj_t* img = lv_img_create(back_btn_);
         lv_img_set_src(img, &img_back);
         lv_obj_center(img);
-        lv_obj_set_style_img_recolor(img, seedsigner::lvgl::theme::colors::TEXT_PRIMARY, 0);
+        lv_obj_set_style_img_recolor(img, seedsigner::lvgl::theme::active_theme().TEXT_PRIMARY, 0);
         lv_obj_set_style_img_recolor_opa(img, LV_OPA_COVER, 0);
-        lv_obj_set_style_img_recolor(img, seedsigner::lvgl::theme::colors::PRIMARY, LV_STATE_PRESSED);
+        lv_obj_set_style_img_recolor(img, seedsigner::lvgl::theme::active_theme().PRIMARY, LV_STATE_PRESSED);
         lv_obj_set_style_img_recolor_opa(img, LV_OPA_COVER, LV_STATE_PRESSED);
         lv_obj_set_style_opa(img, LV_OPA_40, LV_STATE_DISABLED);
     }
@@ -129,9 +129,9 @@ void TopNavBar::create_widgets() {
         lv_obj_t* img = lv_img_create(home_btn_);
         lv_img_set_src(img, &img_home);
         lv_obj_center(img);
-        lv_obj_set_style_img_recolor(img, seedsigner::lvgl::theme::colors::TEXT_PRIMARY, 0);
+        lv_obj_set_style_img_recolor(img, seedsigner::lvgl::theme::active_theme().TEXT_PRIMARY, 0);
         lv_obj_set_style_img_recolor_opa(img, LV_OPA_COVER, 0);
-        lv_obj_set_style_img_recolor(img, seedsigner::lvgl::theme::colors::PRIMARY, LV_STATE_PRESSED);
+        lv_obj_set_style_img_recolor(img, seedsigner::lvgl::theme::active_theme().PRIMARY, LV_STATE_PRESSED);
         lv_obj_set_style_img_recolor_opa(img, LV_OPA_COVER, LV_STATE_PRESSED);
         lv_obj_set_style_opa(img, LV_OPA_40, LV_STATE_DISABLED);
         // If back also exists, add spacing via pad column (flex gap already set)
@@ -146,9 +146,9 @@ void TopNavBar::create_widgets() {
         lv_obj_t* img = lv_img_create(cancel_btn_);
         lv_img_set_src(img, &img_close);
         lv_obj_center(img);
-        lv_obj_set_style_img_recolor(img, seedsigner::lvgl::theme::colors::TEXT_PRIMARY, 0);
+        lv_obj_set_style_img_recolor(img, seedsigner::lvgl::theme::active_theme().TEXT_PRIMARY, 0);
         lv_obj_set_style_img_recolor_opa(img, LV_OPA_COVER, 0);
-        lv_obj_set_style_img_recolor(img, seedsigner::lvgl::theme::colors::PRIMARY, LV_STATE_PRESSED);
+        lv_obj_set_style_img_recolor(img, seedsigner::lvgl::theme::active_theme().PRIMARY, LV_STATE_PRESSED);
         lv_obj_set_style_img_recolor_opa(img, LV_OPA_COVER, LV_STATE_PRESSED);
         lv_obj_set_style_opa(img, LV_OPA_40, LV_STATE_DISABLED);
     }
@@ -156,7 +156,7 @@ void TopNavBar::create_widgets() {
     // Center title
     title_label_ = lv_label_create(container_);
     lv_label_set_text(title_label_, config_.title.c_str());
-    lv_obj_set_style_text_color(title_label_, seedsigner::lvgl::theme::colors::TEXT_PRIMARY, 0);
+    lv_obj_set_style_text_color(title_label_, seedsigner::lvgl::theme::active_theme().TEXT_PRIMARY, 0);
     lv_obj_set_style_text_font(title_label_, seedsigner::lvgl::theme::typography::TITLE, 0);
     lv_obj_set_flex_grow(title_label_, 1);
     lv_obj_set_style_text_align(title_label_, LV_TEXT_ALIGN_CENTER, 0);
@@ -175,8 +175,8 @@ void TopNavBar::create_widgets() {
         lv_obj_add_event_cb(btn, &TopNavBar::on_action_clicked, LV_EVENT_CLICKED, this);
         lv_obj_t* label = lv_label_create(btn);
         lv_label_set_text(label, action.label.c_str());
-        lv_obj_set_style_text_color(label, seedsigner::lvgl::theme::colors::TEXT_PRIMARY, 0);
-        lv_obj_set_style_text_color(label, seedsigner::lvgl::theme::colors::TEXT_DISABLED, LV_STATE_DISABLED);
+        lv_obj_set_style_text_color(label, seedsigner::lvgl::theme::active_theme().TEXT_PRIMARY, 0);
+        lv_obj_set_style_text_color(label, seedsigner::lvgl::theme::active_theme().TEXT_DISABLED, LV_STATE_DISABLED);
         lv_obj_center(label);
         action_buttons_.push_back(btn);
     }

--- a/src/screens/CameraPreviewScreen.cpp
+++ b/src/screens/CameraPreviewScreen.cpp
@@ -58,8 +58,8 @@ void CameraPreviewScreen::create(const ScreenContext& context, const RouteDescri
     frame_label_ = lv_label_create(preview_panel_);
     lv_obj_align(frame_label_, LV_ALIGN_BOTTOM_LEFT, 2, 2);
     lv_obj_set_style_bg_opa(frame_label_, LV_OPA_60, 0);
-    lv_obj_set_style_bg_color(frame_label_, seedsigner::lvgl::theme::colors::BLACK, 0);
-    lv_obj_set_style_text_color(frame_label_, seedsigner::lvgl::theme::colors::TEXT_PRIMARY, 0);
+    lv_obj_set_style_bg_color(frame_label_, seedsigner::lvgl::theme::active_theme().BLACK, 0);
+    lv_obj_set_style_text_color(frame_label_, seedsigner::lvgl::theme::active_theme().TEXT_PRIMARY, 0);
     lv_obj_set_style_pad_all(frame_label_, 4, 0);
 
     status_label_ = lv_label_create(content_container_);

--- a/src/screens/MenuListScreen.cpp
+++ b/src/screens/MenuListScreen.cpp
@@ -59,19 +59,19 @@ void MenuListScreen::create(const ScreenContext& context, const RouteDescriptor&
         lv_style_set_pad_all(&row_style_, seedsigner::lvgl::theme::spacing::ROW_PAD);
         lv_style_set_pad_gap(&row_style_, seedsigner::lvgl::theme::spacing::ROW_GAP);
         lv_style_set_bg_opa(&row_style_, LV_OPA_COVER);
-        lv_style_set_bg_color(&row_style_, seedsigner::lvgl::theme::colors::SURFACE_MEDIUM);
+        lv_style_set_bg_color(&row_style_, seedsigner::lvgl::theme::active_theme().SURFACE_MEDIUM);
         lv_style_set_border_width(&row_style_, 1);
-        lv_style_set_border_color(&row_style_, seedsigner::lvgl::theme::colors::BORDER);
-        lv_style_set_text_color(&row_style_, seedsigner::lvgl::theme::colors::TEXT_PRIMARY);
+        lv_style_set_border_color(&row_style_, seedsigner::lvgl::theme::active_theme().BORDER);
+        lv_style_set_text_color(&row_style_, seedsigner::lvgl::theme::active_theme().TEXT_PRIMARY);
 
         lv_style_init(&selected_row_style_);
         lv_style_set_bg_opa(&selected_row_style_, LV_OPA_50);
-        lv_style_set_bg_color(&selected_row_style_, seedsigner::lvgl::theme::colors::PRIMARY);
+        lv_style_set_bg_color(&selected_row_style_, seedsigner::lvgl::theme::active_theme().PRIMARY);
         lv_style_set_border_width(&selected_row_style_, 2);
-        lv_style_set_border_color(&selected_row_style_, seedsigner::lvgl::theme::colors::PRIMARY_LIGHT);
+        lv_style_set_border_color(&selected_row_style_, seedsigner::lvgl::theme::active_theme().PRIMARY_LIGHT);
         lv_style_set_outline_width(&selected_row_style_, 2);
         lv_style_set_outline_pad(&selected_row_style_, 1);
-        lv_style_set_outline_color(&selected_row_style_, seedsigner::lvgl::theme::colors::PRIMARY);
+        lv_style_set_outline_color(&selected_row_style_, seedsigner::lvgl::theme::active_theme().PRIMARY);
         styles_initialized_ = true;
     }
 
@@ -130,8 +130,8 @@ void MenuListScreen::create(const ScreenContext& context, const RouteDescriptor&
         lv_obj_set_flex_flow(button, LV_FLEX_FLOW_ROW);
         lv_obj_set_flex_align(button, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
         lv_obj_add_style(button, &row_style_, LV_PART_MAIN);
-        lv_obj_set_style_bg_color(button, seedsigner::lvgl::theme::colors::SURFACE_LIGHT, LV_STATE_PRESSED);
-        lv_obj_set_style_border_color(button, seedsigner::lvgl::theme::colors::PRIMARY_LIGHT, LV_STATE_PRESSED);
+        lv_obj_set_style_bg_color(button, seedsigner::lvgl::theme::active_theme().SURFACE_LIGHT, LV_STATE_PRESSED);
+        lv_obj_set_style_border_color(button, seedsigner::lvgl::theme::active_theme().PRIMARY_LIGHT, LV_STATE_PRESSED);
         lv_obj_set_style_translate_y(button, 2, LV_STATE_PRESSED);
         lv_obj_set_style_border_width(button, 2, LV_STATE_PRESSED);
         lv_obj_add_event_cb(button, &MenuListScreen::on_item_event, LV_EVENT_FOCUSED, this);

--- a/src/screens/PSBTDetailScreen.cpp
+++ b/src/screens/PSBTDetailScreen.cpp
@@ -36,7 +36,7 @@ void create_row(lv_obj_t* parent, const char* label_text, const char* value_text
     lv_obj_t* label = lv_label_create(row);
     lv_label_set_text(label, label_text);
     lv_obj_set_width(label, kLabelWidth);
-    lv_obj_set_style_text_color(label, seedsigner::lvgl::theme::colors::TEXT_SECONDARY, 0);
+    lv_obj_set_style_text_color(label, seedsigner::lvgl::theme::active_theme().TEXT_SECONDARY, 0);
 
     lv_obj_t* value = lv_label_create(row);
     lv_label_set_text(value, value_text);
@@ -117,7 +117,7 @@ void PSBTDetailScreen::create(const ScreenContext& context, const RouteDescripto
     // Footer hint
     footer_label_ = lv_label_create(content_container_);
     lv_label_set_text(footer_label_, "Press RIGHT to view QR (placeholder), BACK to return");
-    lv_obj_set_style_text_color(footer_label_, seedsigner::lvgl::theme::colors::TEXT_SECONDARY, 0);
+    lv_obj_set_style_text_color(footer_label_, seedsigner::lvgl::theme::active_theme().TEXT_SECONDARY, 0);
     lv_obj_set_style_text_align(footer_label_, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_set_width(footer_label_, lv_pct(100));
     lv_obj_set_style_pad_top(footer_label_, 16, 0);

--- a/src/screens/PSBTMathScreen.cpp
+++ b/src/screens/PSBTMathScreen.cpp
@@ -57,7 +57,7 @@ RowWidgets create_row(lv_obj_t* parent, const char* icon_symbol, const char* tex
         widgets.value = lv_label_create(widgets.container);
         lv_label_set_text(widgets.value, value_text);
         lv_obj_set_style_pad_left(widgets.value, 8, 0);
-        lv_obj_set_style_text_color(widgets.value, seedsigner::lvgl::theme::colors::TEXT_SECONDARY, 0);
+        lv_obj_set_style_text_color(widgets.value, seedsigner::lvgl::theme::active_theme().TEXT_SECONDARY, 0);
         lv_obj_set_flex_grow(widgets.value, 1);
         lv_obj_set_style_text_align(widgets.value, LV_TEXT_ALIGN_RIGHT, 0);
     } else {
@@ -130,7 +130,7 @@ void PSBTMathScreen::create(const ScreenContext& context, const RouteDescriptor&
     // Footer hint
     footer_label_ = lv_label_create(content_container_);
     lv_label_set_text(footer_label_, "Press OK to continue, BACK to cancel");
-    lv_obj_set_style_text_color(footer_label_, seedsigner::lvgl::theme::colors::TEXT_SECONDARY, 0);
+    lv_obj_set_style_text_color(footer_label_, seedsigner::lvgl::theme::active_theme().TEXT_SECONDARY, 0);
     lv_obj_set_style_text_align(footer_label_, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_set_width(footer_label_, lv_pct(100));
     lv_obj_set_style_pad_top(footer_label_, 16, 0);

--- a/src/screens/PSBTOverviewScreen.cpp
+++ b/src/screens/PSBTOverviewScreen.cpp
@@ -59,7 +59,7 @@ RowWidgets create_row(lv_obj_t* parent, const char* icon_symbol, const char* tex
         widgets.value = lv_label_create(widgets.container);
         lv_label_set_text(widgets.value, value_text);
         lv_obj_set_style_pad_left(widgets.value, 8, 0);
-        lv_obj_set_style_text_color(widgets.value, seedsigner::lvgl::theme::colors::TEXT_SECONDARY, 0);
+        lv_obj_set_style_text_color(widgets.value, seedsigner::lvgl::theme::active_theme().TEXT_SECONDARY, 0);
         lv_obj_set_flex_grow(widgets.value, 1);
         lv_obj_set_style_text_align(widgets.value, LV_TEXT_ALIGN_RIGHT, 0);
     } else {
@@ -103,7 +103,7 @@ void PSBTOverviewScreen::create(const ScreenContext& context, const RouteDescrip
     // Total amount (center prominent)
     amount_label_ = lv_label_create(content_container_);
     lv_label_set_text(amount_label_, params_.total_amount.c_str());
-    lv_obj_set_style_text_color(amount_label_, seedsigner::lvgl::theme::colors::SUCCESS, 0);
+    lv_obj_set_style_text_color(amount_label_, seedsigner::lvgl::theme::active_theme().SUCCESS, 0);
     lv_obj_set_style_text_align(amount_label_, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_set_width(amount_label_, lv_pct(100));
     lv_obj_set_style_pad_bottom(amount_label_, 24, 0);
@@ -160,7 +160,7 @@ void PSBTOverviewScreen::create(const ScreenContext& context, const RouteDescrip
     // Footer hint
     footer_label_ = lv_label_create(content_container_);
     lv_label_set_text(footer_label_, "Press OK to continue, BACK to cancel");
-    lv_obj_set_style_text_color(footer_label_, seedsigner::lvgl::theme::colors::TEXT_SECONDARY, 0);
+    lv_obj_set_style_text_color(footer_label_, seedsigner::lvgl::theme::active_theme().TEXT_SECONDARY, 0);
     lv_obj_set_style_text_align(footer_label_, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_set_width(footer_label_, lv_pct(100));
     lv_obj_set_style_pad_top(footer_label_, 16, 0);

--- a/src/screens/QRDisplayScreen.cpp
+++ b/src/screens/QRDisplayScreen.cpp
@@ -64,7 +64,7 @@ void QRDisplayScreen::create(const ScreenContext& context, const RouteDescriptor
     lv_obj_set_flex_grow(content_container_, 1); // Take remaining height
 
     // QR widget
-    qr_widget_ = lv_qrcode_create(content_container_, kQRSize, seedsigner::lvgl::theme::colors::QR_FOREGROUND, seedsigner::lvgl::theme::colors::QR_BACKGROUND);
+    qr_widget_ = lv_qrcode_create(content_container_, kQRSize, seedsigner::lvgl::theme::active_theme().QR_FOREGROUND, seedsigner::lvgl::theme::active_theme().QR_BACKGROUND);
     if (!qr_widget_) {
         // fallback: create a placeholder label
         lv_obj_t* error = lv_label_create(content_container_);
@@ -77,7 +77,7 @@ void QRDisplayScreen::create(const ScreenContext& context, const RouteDescriptor
     // Brightness overlay (black semi-transparent rectangle covering entire QR)
     brightness_overlay_ = lv_obj_create(qr_widget_);
     lv_obj_set_size(brightness_overlay_, lv_pct(100), lv_pct(100));
-    lv_obj_set_style_bg_color(brightness_overlay_, seedsigner::lvgl::theme::colors::BLACK, 0);
+    lv_obj_set_style_bg_color(brightness_overlay_, seedsigner::lvgl::theme::active_theme().BLACK, 0);
     lv_obj_set_style_bg_opa(brightness_overlay_, LV_OPA_TRANSP, 0); // updated by update_brightness_overlay
     lv_obj_set_style_border_width(brightness_overlay_, 0, 0);
     lv_obj_set_style_radius(brightness_overlay_, 0, 0);

--- a/src/screens/ScanScreen.cpp
+++ b/src/screens/ScanScreen.cpp
@@ -45,7 +45,7 @@ void ScanScreen::create(const ScreenContext& context, const RouteDescriptor& rou
     // Create root container
     container_ = lv_obj_create(context.root);
     lv_obj_set_size(container_, lv_pct(100), lv_pct(100));
-    lv_obj_set_style_bg_color(container_, seedsigner::lvgl::theme::colors::SURFACE_DARK, 0);
+    lv_obj_set_style_bg_color(container_, seedsigner::lvgl::theme::active_theme().SURFACE_DARK, 0);
     lv_obj_set_style_border_width(container_, 0, 0);
     lv_obj_set_flex_flow(container_, LV_FLEX_FLOW_COLUMN);
     lv_obj_set_flex_align(container_, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
@@ -65,7 +65,7 @@ void ScanScreen::create(const ScreenContext& context, const RouteDescriptor& rou
     // Content container (everything below the nav bar)
     content_container_ = lv_obj_create(container_);
     lv_obj_set_size(content_container_, lv_pct(100), lv_pct(100));
-    lv_obj_set_style_bg_color(content_container_, seedsigner::lvgl::theme::colors::SURFACE_DARK, 0);
+    lv_obj_set_style_bg_color(content_container_, seedsigner::lvgl::theme::active_theme().SURFACE_DARK, 0);
     lv_obj_set_style_border_width(content_container_, 0, 0);
     lv_obj_set_style_pad_all(content_container_, 0, 0);
     lv_obj_set_flex_grow(content_container_, 1); // Take remaining height
@@ -74,7 +74,7 @@ void ScanScreen::create(const ScreenContext& context, const RouteDescriptor& rou
     preview_img_ = lv_canvas_create(content_container_);
     lv_obj_set_size(preview_img_, kPreviewWidth, kPreviewHeight);
     lv_obj_align(preview_img_, LV_ALIGN_CENTER, 0, 0);
-    lv_canvas_fill_bg(preview_img_, seedsigner::lvgl::theme::colors::BLACK, LV_OPA_COVER);
+    lv_canvas_fill_bg(preview_img_, seedsigner::lvgl::theme::active_theme().BLACK, LV_OPA_COVER);
     
     // Instruction label removed – title is shown in TopNavBar
     instruction_label_ = nullptr;
@@ -85,9 +85,9 @@ void ScanScreen::create(const ScreenContext& context, const RouteDescriptor& rou
     lv_obj_align(progress_bar_, LV_ALIGN_BOTTOM_MID, 0, -40);
     lv_bar_set_range(progress_bar_, 0, 100);
     lv_bar_set_value(progress_bar_, 0, LV_ANIM_OFF);
-    lv_obj_set_style_bg_color(progress_bar_, seedsigner::lvgl::theme::colors::SURFACE_MEDIUM, 0);
+    lv_obj_set_style_bg_color(progress_bar_, seedsigner::lvgl::theme::active_theme().SURFACE_MEDIUM, 0);
     lv_obj_set_style_bg_opa(progress_bar_, LV_OPA_COVER, 0);
-    lv_obj_set_style_bg_color(progress_bar_, seedsigner::lvgl::theme::colors::SUCCESS, LV_PART_INDICATOR);
+    lv_obj_set_style_bg_color(progress_bar_, seedsigner::lvgl::theme::active_theme().SUCCESS, LV_PART_INDICATOR);
     lv_obj_set_style_bg_opa(progress_bar_, LV_OPA_COVER, LV_PART_INDICATOR);
     lv_obj_add_flag(progress_bar_, LV_OBJ_FLAG_HIDDEN);
     
@@ -95,7 +95,7 @@ void ScanScreen::create(const ScreenContext& context, const RouteDescriptor& rou
     progress_label_ = lv_label_create(content_container_);
     lv_label_set_text(progress_label_, "0%");
     lv_obj_align_to(progress_label_, progress_bar_, LV_ALIGN_OUT_BOTTOM_MID, 0, 5);
-    lv_obj_set_style_text_color(progress_label_, seedsigner::lvgl::theme::colors::TEXT_PRIMARY, 0);
+    lv_obj_set_style_text_color(progress_label_, seedsigner::lvgl::theme::active_theme().TEXT_PRIMARY, 0);
     lv_obj_set_style_text_font(progress_label_, &lv_font_montserrat_14, 0);
     lv_obj_add_flag(progress_label_, LV_OBJ_FLAG_HIDDEN);
     
@@ -104,7 +104,7 @@ void ScanScreen::create(const ScreenContext& context, const RouteDescriptor& rou
     lv_obj_set_size(frame_status_dot_, kDotSize, kDotSize);
     lv_obj_align(frame_status_dot_, LV_ALIGN_BOTTOM_RIGHT, -kDotMargin, -kDotMargin);
     lv_obj_set_style_radius(frame_status_dot_, LV_RADIUS_CIRCLE, 0);
-    lv_obj_set_style_bg_color(frame_status_dot_, seedsigner::lvgl::theme::colors::ERROR, 0); // red initially
+    lv_obj_set_style_bg_color(frame_status_dot_, seedsigner::lvgl::theme::active_theme().ERROR, 0); // red initially
     lv_obj_set_style_bg_opa(frame_status_dot_, LV_OPA_COVER, 0);
     lv_obj_set_style_border_width(frame_status_dot_, 0, 0);
     lv_obj_clear_flag(frame_status_dot_, LV_OBJ_FLAG_CLICKABLE);
@@ -180,7 +180,7 @@ bool ScanScreen::push_frame(const CameraFrame& frame) {
         const std::uint32_t y_offset = (target_height - scaled_height) / 2;
         
         // Fill background black
-        lv_canvas_fill_bg(preview_img_, seedsigner::lvgl::theme::colors::BLACK, LV_OPA_COVER);
+        lv_canvas_fill_bg(preview_img_, seedsigner::lvgl::theme::active_theme().BLACK, LV_OPA_COVER);
         
         // Draw scaled grayscale pixels
         for (std::uint32_t y = 0; y < scaled_height; ++y) {
@@ -233,7 +233,7 @@ void ScanScreen::update_progress(unsigned int percent) {
 
 void ScanScreen::update_frame_status(bool valid) {
     frame_valid_ = valid;
-    lv_obj_set_style_bg_color(frame_status_dot_, valid ? seedsigner::lvgl::theme::colors::SUCCESS : seedsigner::lvgl::theme::colors::ERROR, 0);
+    lv_obj_set_style_bg_color(frame_status_dot_, valid ? seedsigner::lvgl::theme::active_theme().SUCCESS : seedsigner::lvgl::theme::active_theme().ERROR, 0);
     // Optionally emit event
     context_.emit_action(kFrameStatusUpdatedAction, kScanScreenComponent, EventValue{valid});
 }

--- a/src/screens/ScreensaverScreen.cpp
+++ b/src/screens/ScreensaverScreen.cpp
@@ -40,7 +40,7 @@ void ScreensaverScreen::create(const ScreenContext& context, const RouteDescript
 
     container_ = lv_obj_create(context.root);
     lv_obj_set_size(container_, lv_pct(100), lv_pct(100));
-    lv_obj_set_style_bg_color(container_, seedsigner::lvgl::theme::colors::BLACK, 0);
+    lv_obj_set_style_bg_color(container_, seedsigner::lvgl::theme::active_theme().BLACK, 0);
     lv_obj_set_style_bg_opa(container_, LV_OPA_COVER, 0);
     lv_obj_clear_flag(container_, LV_OBJ_FLAG_SCROLLABLE);
 
@@ -52,7 +52,7 @@ void ScreensaverScreen::create(const ScreenContext& context, const RouteDescript
     if (params_.show_wakeup_overlay) {
         wakeup_overlay_ = lv_obj_create(container_);
         lv_obj_set_size(wakeup_overlay_, lv_pct(100), lv_pct(100));
-        lv_obj_set_style_bg_color(wakeup_overlay_, seedsigner::lvgl::theme::colors::BLACK, 0);
+        lv_obj_set_style_bg_color(wakeup_overlay_, seedsigner::lvgl::theme::active_theme().BLACK, 0);
         lv_obj_set_style_bg_opa(wakeup_overlay_, LV_OPA_50, 0);
         lv_obj_set_style_pad_all(wakeup_overlay_, 0, 0);
         lv_obj_add_flag(wakeup_overlay_, LV_OBJ_FLAG_HIDDEN);
@@ -60,7 +60,7 @@ void ScreensaverScreen::create(const ScreenContext& context, const RouteDescript
         lv_obj_t* label = lv_label_create(wakeup_overlay_);
         lv_label_set_text(label, "Touch to continue");
         lv_obj_set_style_text_font(label, &lv_font_montserrat_14, 0);
-        lv_obj_set_style_text_color(label, seedsigner::lvgl::theme::colors::TEXT_PRIMARY, 0);
+        lv_obj_set_style_text_color(label, seedsigner::lvgl::theme::active_theme().TEXT_PRIMARY, 0);
         lv_obj_center(label);
     }
 

--- a/src/screens/SeedWordsScreen.cpp
+++ b/src/screens/SeedWordsScreen.cpp
@@ -42,20 +42,20 @@ void SeedWordsScreen::create(const ScreenContext& context, const RouteDescriptor
         lv_style_init(&chip_style_);
         lv_style_set_radius(&chip_style_, seedsigner::lvgl::theme::spacing::CHIP_RADIUS);
         lv_style_set_bg_opa(&chip_style_, LV_OPA_20);
-        lv_style_set_bg_color(&chip_style_, seedsigner::lvgl::theme::colors::SURFACE_MEDIUM);
+        lv_style_set_bg_color(&chip_style_, seedsigner::lvgl::theme::active_theme().SURFACE_MEDIUM);
         lv_style_set_border_width(&chip_style_, 1);
-        lv_style_set_border_color(&chip_style_, seedsigner::lvgl::theme::colors::BORDER);
+        lv_style_set_border_color(&chip_style_, seedsigner::lvgl::theme::active_theme().BORDER);
         lv_style_set_pad_all(&chip_style_, 6);
-        lv_style_set_text_color(&chip_style_, seedsigner::lvgl::theme::colors::TEXT_PRIMARY);
+        lv_style_set_text_color(&chip_style_, seedsigner::lvgl::theme::active_theme().TEXT_PRIMARY);
         
         lv_style_init(&warning_chip_style_);
         lv_style_set_radius(&warning_chip_style_, seedsigner::lvgl::theme::spacing::CHIP_RADIUS);
         lv_style_set_bg_opa(&warning_chip_style_, LV_OPA_20);
-        lv_style_set_bg_color(&warning_chip_style_, seedsigner::lvgl::theme::colors::PRIMARY);
+        lv_style_set_bg_color(&warning_chip_style_, seedsigner::lvgl::theme::active_theme().PRIMARY);
         lv_style_set_border_width(&warning_chip_style_, 2);
-        lv_style_set_border_color(&warning_chip_style_, seedsigner::lvgl::theme::colors::PRIMARY);
+        lv_style_set_border_color(&warning_chip_style_, seedsigner::lvgl::theme::active_theme().PRIMARY);
         lv_style_set_pad_all(&warning_chip_style_, 6);
-        lv_style_set_text_color(&warning_chip_style_, seedsigner::lvgl::theme::colors::TEXT_PRIMARY);
+        lv_style_set_text_color(&warning_chip_style_, seedsigner::lvgl::theme::active_theme().TEXT_PRIMARY);
         styles_initialized_ = true;
     }
     
@@ -100,7 +100,7 @@ void SeedWordsScreen::create(const ScreenContext& context, const RouteDescriptor
     lv_label_set_long_mode(warning_label_, LV_LABEL_LONG_WRAP);
     lv_label_set_text(warning_label_, warning.c_str());
     lv_obj_set_style_text_align(warning_label_, LV_TEXT_ALIGN_CENTER, 0);
-    lv_obj_set_style_text_color(warning_label_, seedsigner::lvgl::theme::colors::WARNING, 0);
+    lv_obj_set_style_text_color(warning_label_, seedsigner::lvgl::theme::active_theme().WARNING, 0);
     lv_obj_set_style_pad_bottom(warning_label_, 10, 0);
     
     // Words container (grid)

--- a/src/screens/SettingsMenuScreen.cpp
+++ b/src/screens/SettingsMenuScreen.cpp
@@ -76,19 +76,19 @@ void SettingsMenuScreen::create(const ScreenContext& context, const RouteDescrip
         lv_style_set_pad_all(&row_style_, seedsigner::lvgl::theme::spacing::ROW_PAD);
         lv_style_set_pad_gap(&row_style_, seedsigner::lvgl::theme::spacing::ROW_GAP);
         lv_style_set_bg_opa(&row_style_, LV_OPA_COVER);
-        lv_style_set_bg_color(&row_style_, seedsigner::lvgl::theme::colors::SURFACE_MEDIUM);
+        lv_style_set_bg_color(&row_style_, seedsigner::lvgl::theme::active_theme().SURFACE_MEDIUM);
         lv_style_set_border_width(&row_style_, 1);
-        lv_style_set_border_color(&row_style_, seedsigner::lvgl::theme::colors::BORDER);
-        lv_style_set_text_color(&row_style_, seedsigner::lvgl::theme::colors::TEXT_PRIMARY);
+        lv_style_set_border_color(&row_style_, seedsigner::lvgl::theme::active_theme().BORDER);
+        lv_style_set_text_color(&row_style_, seedsigner::lvgl::theme::active_theme().TEXT_PRIMARY);
 
         lv_style_init(&selected_row_style_);
         lv_style_set_bg_opa(&selected_row_style_, LV_OPA_50);
-        lv_style_set_bg_color(&selected_row_style_, seedsigner::lvgl::theme::colors::PRIMARY);
+        lv_style_set_bg_color(&selected_row_style_, seedsigner::lvgl::theme::active_theme().PRIMARY);
         lv_style_set_border_width(&selected_row_style_, 2);
-        lv_style_set_border_color(&selected_row_style_, seedsigner::lvgl::theme::colors::PRIMARY_LIGHT);
+        lv_style_set_border_color(&selected_row_style_, seedsigner::lvgl::theme::active_theme().PRIMARY_LIGHT);
         lv_style_set_outline_width(&selected_row_style_, 2);
         lv_style_set_outline_pad(&selected_row_style_, 1);
-        lv_style_set_outline_color(&selected_row_style_, seedsigner::lvgl::theme::colors::PRIMARY);
+        lv_style_set_outline_color(&selected_row_style_, seedsigner::lvgl::theme::active_theme().PRIMARY);
         styles_initialized_ = true;
     }
 
@@ -162,8 +162,8 @@ void SettingsMenuScreen::create(const ScreenContext& context, const RouteDescrip
         lv_obj_set_flex_flow(button, LV_FLEX_FLOW_ROW);
         lv_obj_set_flex_align(button, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
         lv_obj_add_style(button, &row_style_, LV_PART_MAIN);
-        lv_obj_set_style_bg_color(button, seedsigner::lvgl::theme::colors::SURFACE_LIGHT, LV_STATE_PRESSED);
-        lv_obj_set_style_border_color(button, seedsigner::lvgl::theme::colors::PRIMARY_LIGHT, LV_STATE_PRESSED);
+        lv_obj_set_style_bg_color(button, seedsigner::lvgl::theme::active_theme().SURFACE_LIGHT, LV_STATE_PRESSED);
+        lv_obj_set_style_border_color(button, seedsigner::lvgl::theme::active_theme().PRIMARY_LIGHT, LV_STATE_PRESSED);
         lv_obj_set_style_translate_y(button, 2, LV_STATE_PRESSED);
         lv_obj_set_style_border_width(button, 2, LV_STATE_PRESSED);
         lv_obj_add_event_cb(button, &SettingsMenuScreen::on_item_event, LV_EVENT_FOCUSED, this);

--- a/src/screens/SettingsSelectionScreen.cpp
+++ b/src/screens/SettingsSelectionScreen.cpp
@@ -69,19 +69,19 @@ void SettingsSelectionScreen::create(const ScreenContext& context, const RouteDe
         lv_style_set_pad_all(&row_style_, seedsigner::lvgl::theme::spacing::ROW_PAD);
         lv_style_set_pad_gap(&row_style_, seedsigner::lvgl::theme::spacing::ROW_GAP);
         lv_style_set_bg_opa(&row_style_, LV_OPA_COVER);
-        lv_style_set_bg_color(&row_style_, seedsigner::lvgl::theme::colors::SURFACE_MEDIUM);
+        lv_style_set_bg_color(&row_style_, seedsigner::lvgl::theme::active_theme().SURFACE_MEDIUM);
         lv_style_set_border_width(&row_style_, 1);
-        lv_style_set_border_color(&row_style_, seedsigner::lvgl::theme::colors::BORDER);
-        lv_style_set_text_color(&row_style_, seedsigner::lvgl::theme::colors::TEXT_PRIMARY);
+        lv_style_set_border_color(&row_style_, seedsigner::lvgl::theme::active_theme().BORDER);
+        lv_style_set_text_color(&row_style_, seedsigner::lvgl::theme::active_theme().TEXT_PRIMARY);
 
         lv_style_init(&selected_row_style_);
         lv_style_set_bg_opa(&selected_row_style_, LV_OPA_50);
-        lv_style_set_bg_color(&selected_row_style_, seedsigner::lvgl::theme::colors::PRIMARY);
+        lv_style_set_bg_color(&selected_row_style_, seedsigner::lvgl::theme::active_theme().PRIMARY);
         lv_style_set_border_width(&selected_row_style_, 2);
-        lv_style_set_border_color(&selected_row_style_, seedsigner::lvgl::theme::colors::PRIMARY_LIGHT);
+        lv_style_set_border_color(&selected_row_style_, seedsigner::lvgl::theme::active_theme().PRIMARY_LIGHT);
         lv_style_set_outline_width(&selected_row_style_, 2);
         lv_style_set_outline_pad(&selected_row_style_, 1);
-        lv_style_set_outline_color(&selected_row_style_, seedsigner::lvgl::theme::colors::PRIMARY);
+        lv_style_set_outline_color(&selected_row_style_, seedsigner::lvgl::theme::active_theme().PRIMARY);
         styles_initialized_ = true;
     }
 
@@ -156,8 +156,8 @@ void SettingsSelectionScreen::create(const ScreenContext& context, const RouteDe
             lv_obj_set_flex_flow(button, LV_FLEX_FLOW_ROW);
             lv_obj_set_flex_align(button, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
             lv_obj_add_style(button, &row_style_, LV_PART_MAIN);
-            lv_obj_set_style_bg_color(button, seedsigner::lvgl::theme::colors::SURFACE_LIGHT, LV_STATE_PRESSED);
-            lv_obj_set_style_border_color(button, seedsigner::lvgl::theme::colors::PRIMARY_LIGHT, LV_STATE_PRESSED);
+            lv_obj_set_style_bg_color(button, seedsigner::lvgl::theme::active_theme().SURFACE_LIGHT, LV_STATE_PRESSED);
+            lv_obj_set_style_border_color(button, seedsigner::lvgl::theme::active_theme().PRIMARY_LIGHT, LV_STATE_PRESSED);
             lv_obj_set_style_translate_y(button, 2, LV_STATE_PRESSED);
             lv_obj_set_style_border_width(button, 2, LV_STATE_PRESSED);
             lv_obj_add_event_cb(button, &SettingsSelectionScreen::on_item_event, LV_EVENT_FOCUSED, this);

--- a/src/screens/WarningScreen.cpp
+++ b/src/screens/WarningScreen.cpp
@@ -197,12 +197,12 @@ const lv_img_dsc_t* WarningScreen::severity_to_icon(WarningSeverity severity) {
 lv_color_t WarningScreen::severity_to_title_color(WarningSeverity severity) {
     switch (severity) {
     case WarningSeverity::Error:
-        return seedsigner::lvgl::theme::colors::ERROR;
+        return seedsigner::lvgl::theme::active_theme().ERROR;
     case WarningSeverity::DireWarning:
-        return seedsigner::lvgl::theme::colors::WARNING; // Orange-amber
+        return seedsigner::lvgl::theme::active_theme().WARNING; // Orange-amber
     case WarningSeverity::Warning:
     default:
-        return seedsigner::lvgl::theme::colors::WARNING; // Amber for both warning levels
+        return seedsigner::lvgl::theme::active_theme().WARNING; // Amber for both warning levels
     }
 }
 

--- a/src/visual/SeedSignerTheme.cpp
+++ b/src/visual/SeedSignerTheme.cpp
@@ -1,0 +1,84 @@
+#include "seedsigner_lvgl/visual/SeedSignerTheme.hpp"
+
+namespace seedsigner::lvgl::theme {
+
+// ---------------------------------------------------------------------------
+// Dark palette — exact visual parity with the original constants
+// ---------------------------------------------------------------------------
+const ThemeColors DarkPalette = {
+    /* BLACK           */ lv_color_hex(0x000000),
+    /* SURFACE_DARK    */ lv_color_hex(0x1a1a1a),
+    /* SURFACE_MEDIUM  */ lv_color_hex(0x222222),
+    /* SURFACE_LIGHT   */ lv_color_hex(0x2a2a2a),
+    /* SURFACE_DISABLED*/ lv_color_hex(0x111111),
+
+    /* PRIMARY         */ lv_color_hex(0xFF9900),
+    /* PRIMARY_LIGHT   */ lv_color_hex(0xFFB340),
+    /* PRIMARY_DARK    */ lv_color_hex(0xCC7A00),
+
+    /* TEXT_PRIMARY    */ lv_color_hex(0xFFFFFF),
+    /* TEXT_SECONDARY  */ lv_color_hex(0xAAAAAA),
+    /* TEXT_DISABLED   */ lv_color_hex(0x555555),
+
+    /* SUCCESS         */ lv_color_hex(0x00AA00),
+    /* WARNING         */ lv_color_hex(0xFFAA00),
+    /* ERROR           */ lv_color_hex(0xFF3333),
+    /* INFO            */ lv_color_hex(0x3399FF),
+
+    /* BORDER          */ lv_color_hex(0x333333),
+    /* DIVIDER         */ lv_color_hex(0x444444),
+
+    /* QR_BACKGROUND   */ lv_color_hex(0xFFFFFF),
+    /* QR_FOREGROUND   */ lv_color_hex(0x000000),
+};
+
+// ---------------------------------------------------------------------------
+// Light palette — inverted contrast, readable on bright backgrounds
+// ---------------------------------------------------------------------------
+const ThemeColors LightPalette = {
+    /* BLACK           */ lv_color_hex(0xFFFFFF),
+    /* SURFACE_DARK    */ lv_color_hex(0xF0F0F0),
+    /* SURFACE_MEDIUM  */ lv_color_hex(0xE0E0E0),
+    /* SURFACE_LIGHT   */ lv_color_hex(0xD0D0D0),
+    /* SURFACE_DISABLED*/ lv_color_hex(0xC0C0C0),
+
+    /* PRIMARY         */ lv_color_hex(0xE68A00),
+    /* PRIMARY_LIGHT   */ lv_color_hex(0xCC7A00),
+    /* PRIMARY_DARK    */ lv_color_hex(0xFF9900),
+
+    /* TEXT_PRIMARY    */ lv_color_hex(0x111111),
+    /* TEXT_SECONDARY  */ lv_color_hex(0x555555),
+    /* TEXT_DISABLED   */ lv_color_hex(0x999999),
+
+    /* SUCCESS         */ lv_color_hex(0x008800),
+    /* WARNING         */ lv_color_hex(0xCC8800),
+    /* ERROR           */ lv_color_hex(0xCC0000),
+    /* INFO            */ lv_color_hex(0x2266CC),
+
+    /* BORDER          */ lv_color_hex(0xCCCCCC),
+    /* DIVIDER         */ lv_color_hex(0xBBBBBB),
+
+    /* QR_BACKGROUND   */ lv_color_hex(0xFFFFFF),
+    /* QR_FOREGROUND   */ lv_color_hex(0x000000),
+};
+
+// ---------------------------------------------------------------------------
+// Runtime state
+// ---------------------------------------------------------------------------
+static const ThemeColors* g_active = &DarkPalette;
+static ThemeVariant g_variant = ThemeVariant::Dark;
+
+const ThemeColors& active_theme() { return *g_active; }
+
+ThemeVariant current_theme_variant() { return g_variant; }
+
+void set_theme(ThemeVariant variant) {
+    g_variant = variant;
+    g_active = (variant == ThemeVariant::Light) ? &LightPalette : &DarkPalette;
+    // Invalidate the active screen so LVGL repaints with new colors
+    if (lv_obj_t* scr = lv_scr_act()) {
+        lv_obj_invalidate(scr);
+    }
+}
+
+} // namespace seedsigner::lvgl::theme


### PR DESCRIPTION
## Summary

Implements **A4: Dynamic theme support** as described in #65.

Adds a `ThemeColors` struct, `DarkPalette` (current default, pixel-identical) and `LightPalette`, with a global `active_theme()` accessor and `set_theme()` setter that invalidates the active screen for repaint.

### Changes
- `ThemeColors` struct + two static palette instances
- `active_theme()` / `set_theme(ThemeVariant)` runtime API
- Search-replace refactor of all hardcoded `colors::*` → `active_theme().X`
- New `SeedSignerTheme.cpp` implementation

### Testing
- ✅ Build OK
- ✅ ctest 1/1 pass
- ✅ screenshot_tests 11/11 OK (dark palette — visual parity confirmed)
- ✅ No gaps in test coverage

Closes #65