### PR TITLE
feat(desktop): JSON scenario loader/replay for desktop runner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,14 +89,22 @@ if(BUILD_HOST_DESKTOP)
   find_package(PkgConfig REQUIRED)
   pkg_check_modules(SDL2 REQUIRED sdl2)
 
+  # nlohmann/json for scenario loader
+  FetchContent_Declare(
+    nlohmann_json
+    URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
+  )
+  FetchContent_MakeAvailable(nlohmann_json)
+
   add_executable(host_desktop_demo
     examples/host_desktop_demo.cpp
     src/platform/SdlDisplay.cpp
+    src/desktop/ScenarioRunner.cpp
   )
   target_include_directories(host_desktop_demo PRIVATE
     ${SDL2_INCLUDE_DIRS}
   )
-  target_link_libraries(host_desktop_demo PRIVATE seedsigner_lvgl ${SDL2_LIBRARIES})
+  target_link_libraries(host_desktop_demo PRIVATE seedsigner_lvgl ${SDL2_LIBRARIES} nlohmann_json::nlohmann_json)
   target_compile_options(host_desktop_demo PRIVATE ${SDL2_CFLAGS_OTHER})
 endif()
 

--- a/examples/host_desktop_demo.cpp
+++ b/examples/host_desktop_demo.cpp
@@ -13,12 +13,15 @@
 //   ./build-desktop/host_desktop_demo
 
 #include <cstdio>
+#include <cstdlib>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include <SDL.h>
 #include <lvgl.h>
+
+#include "seedsigner_lvgl/desktop/ScenarioRunner.hpp"
 
 #include "seedsigner_lvgl/platform/SdlDisplay.hpp"
 #include "seedsigner_lvgl/visual/DisplayProfile.hpp"
@@ -92,8 +95,21 @@ static std::optional<InputEvent> map_key(SDL_Keycode sym) {
     }
 }
 
-int main() {
+static std::string find_arg(int argc, char** argv, const std::string& flag) {
+    for (int i = 1; i < argc - 1; ++i) {
+        if (argv[i] == flag) return argv[i + 1];
+    }
+    return {};
+}
+
+int main(int argc, char** argv) {
+    const std::string scenario_path = find_arg(argc, argv, "--scenario");
+    const bool interactive = (scenario_path.empty()) || (find_arg(argc, argv, "--interactive") == "true");
+
     std::printf("=== SeedSigner LVGL Interactive Desktop Demo ===\n");
+    if (!scenario_path.empty()) {
+        std::printf("Scenario mode: %s\n", scenario_path.c_str());
+    }
     std::printf("Keys: arrows=nav  Enter=select  Esc=back/quit  1-5=switch screen  F2=switch profile\n");
     std::printf("Mouse: click/tap to interact with touch-oriented screens\n\n");
 
@@ -115,6 +131,26 @@ int main() {
     runtime.init();
 
     register_routes(runtime.screen_registry());
+
+    // ---- Scenario mode (headless) ----
+    if (!scenario_path.empty()) {
+        // Run scenario in headless mode (no SDL window) so screenshots work.
+        UiRuntime headless_rt(RuntimeConfig{.width = kProfiles[0].w, .height = kProfiles[0].h});
+        headless_rt.init();
+        register_routes(headless_rt.screen_registry());
+
+        auto res = ScenarioRunner::load_and_run(scenario_path, headless_rt,
+                                                 kProfiles[0].w, kProfiles[0].h);
+        if (!res.ok) {
+            std::fprintf(stderr, "Scenario failed after %d steps: %s\n",
+                         res.steps_run, res.error.c_str());
+            return 1;
+        }
+        std::printf("Scenario completed: %d steps\n", res.steps_run);
+        if (!interactive) return 0;
+        std::printf("Dropping into interactive mode...\n\n");
+    }
+    // ---- End scenario mode ----
 
     auto go = [&](const DemoScreen& ds) {
         runtime.activate({.route_id = RouteId{ds.route}, .args = ds.args});

--- a/examples/scenarios/main_menu_walk.json
+++ b/examples/scenarios/main_menu_walk.json
@@ -1,0 +1,24 @@
+{
+  "profile": [240, 320],
+  "default_delay_ms": 80,
+  "steps": [
+    {
+      "action": "activate",
+      "route": "demo.menu",
+      "args": {
+        "title": "Main Menu",
+        "items": "settings|Settings|Configure the device|chevron\nscan|Scan QR|Open camera to scan a QR code|chevron\ntools|Tools|Seed tools and utilities|chevron\ninfo|About|Device info & version|chevron"
+      }
+    },
+    { "action": "screenshot", "path": "scenario/main_menu.png" },
+    { "action": "input", "key": "Down", "delay_ms": 100 },
+    { "action": "input", "key": "Down", "delay_ms": 100 },
+    { "action": "screenshot", "path": "scenario/main_menu_scan_highlighted.png" },
+    { "action": "input", "key": "Back" },
+    { "action": "activate",
+      "route": "demo.result",
+      "args": { "title": "Success", "body": "Scenario replay complete!" }
+    },
+    { "action": "screenshot", "path": "scenario/result_screen.png" }
+  ]
+}

--- a/include/seedsigner_lvgl/desktop/ScenarioRunner.hpp
+++ b/include/seedsigner_lvgl/desktop/ScenarioRunner.hpp
@@ -1,0 +1,38 @@
+#pragma once
+// ScenarioRunner — loads a JSON scenario file and replays it against a UiRuntime.
+//
+// Scenario JSON schema:
+// {
+//   "profile": [240, 320],          // optional, default [240,320]
+//   "default_delay_ms": 100,        // optional, default 50
+//   "steps": [
+//     { "action": "activate", "route": "demo.menu", "args": { ... } },
+//     { "action": "input", "key": "Down", "delay_ms": 100 },
+//     { "action": "screenshot", "path": "out/menu.png" },
+//     { "action": "wait", "ms": 500 }
+//   ]
+// }
+
+#include <cstdint>
+#include <string>
+
+namespace seedsigner::lvgl {
+
+class UiRuntime;
+
+struct ScenarioResult {
+    bool ok{false};
+    int steps_run{0};
+    std::string error;
+};
+
+class ScenarioRunner {
+public:
+    /// Load and validate a scenario from `path`.
+    static ScenarioResult load_and_run(const std::string& path,
+                                       UiRuntime& runtime,
+                                       uint32_t runtime_width,
+                                       uint32_t runtime_height);
+};
+
+}  // namespace seedsigner::lvgl

--- a/src/desktop/ScenarioRunner.cpp
+++ b/src/desktop/ScenarioRunner.cpp
@@ -1,0 +1,156 @@
+#include "seedsigner_lvgl/desktop/ScenarioRunner.hpp"
+#include "seedsigner_lvgl/runtime/UiRuntime.hpp"
+#include "seedsigner_lvgl/platform/FramebufferCapture.hpp"
+#include "seedsigner_lvgl/contracts/RouteDescriptor.hpp"
+#include "seedsigner_lvgl/runtime/InputEvent.hpp"
+
+#include <cstdio>
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <stdexcept>
+#include <thread>
+#include <chrono>
+
+namespace seedsigner::lvgl {
+namespace {
+
+using json = nlohmann::json;
+
+InputKey parse_input_key(const std::string& name) {
+    if (name == "Up")    return InputKey::Up;
+    if (name == "Down")  return InputKey::Down;
+    if (name == "Left")  return InputKey::Left;
+    if (name == "Right") return InputKey::Right;
+    if (name == "Press") return InputKey::Press;
+    if (name == "Back")  return InputKey::Back;
+    throw std::runtime_error("unknown input key: " + name);
+}
+
+PropertyMap json_to_props(const json& obj) {
+    PropertyMap m;
+    if (!obj.is_object()) return m;
+    for (auto it = obj.begin(); it != obj.end(); ++it) {
+        if (it.value().is_string()) {
+            m[it.key()] = it.value().get<std::string>();
+        } else if (it.value().is_number()) {
+            m[it.key()] = std::to_string(it.value().get<int>());
+        } else if (it.value().is_boolean()) {
+            m[it.key()] = it.value().get<bool>() ? "true" : "false";
+        }
+    }
+    return m;
+}
+
+void drain_events(UiRuntime& rt) {
+    while (rt.next_event()) {}
+}
+
+}  // namespace
+
+ScenarioResult ScenarioRunner::load_and_run(const std::string& path,
+                                             UiRuntime& runtime,
+                                             uint32_t /*runtime_width*/,
+                                             uint32_t /*runtime_height*/) {
+    ScenarioResult result;
+
+    // Load file
+    std::ifstream f(path);
+    if (!f.is_open()) {
+        result.error = "cannot open scenario file: " + path;
+        return result;
+    }
+
+    json scenario;
+    try {
+        scenario = json::parse(f);
+    } catch (const json::parse_error& e) {
+        result.error = std::string("JSON parse error: ") + e.what();
+        return result;
+    }
+
+    // Validate top-level
+    if (!scenario.contains("steps") || !scenario["steps"].is_array()) {
+        result.error = "scenario must contain a 'steps' array";
+        return result;
+    }
+
+    const uint32_t default_delay = scenario.value("default_delay_ms", 50u);
+    const auto& steps = scenario["steps"];
+
+    for (const auto& step : steps) {
+        if (!step.contains("action") || !step["action"].is_string()) {
+            result.error = "each step must have a string 'action' field";
+            return result;
+        }
+        const std::string action = step["action"];
+
+        try {
+            if (action == "activate") {
+                if (!step.contains("route") || !step["route"].is_string()) {
+                    result.error = "'activate' step needs a string 'route' field";
+                    return result;
+                }
+                RouteDescriptor desc;
+                desc.route_id = RouteId{step["route"].get<std::string>()};
+                if (step.contains("args") && step["args"].is_object()) {
+                    desc.args = json_to_props(step["args"]);
+                }
+                runtime.activate(desc);
+                drain_events(runtime);
+
+            } else if (action == "input") {
+                if (!step.contains("key") || !step["key"].is_string()) {
+                    result.error = "'input' step needs a string 'key' field";
+                    return result;
+                }
+                InputKey key = parse_input_key(step["key"].get<std::string>());
+                runtime.send_input(InputEvent{key});
+                drain_events(runtime);
+
+            } else if (action == "screenshot") {
+                if (!step.contains("path") || !step["path"].is_string()) {
+                    result.error = "'screenshot' step needs a string 'path' field";
+                    return result;
+                }
+                const std::string sp = step["path"].get<std::string>();
+                runtime.refresh_now();
+                const auto* disp = runtime.display();
+                if (!disp) {
+                    result.error = "no headless display available for screenshot";
+                    return result;
+                }
+                if (!FramebufferCapture::write_png(sp, *disp)) {
+                    result.error = "failed to write screenshot: " + sp;
+                    return result;
+                }
+                std::printf("[scenario] screenshot → %s\n", sp.c_str());
+
+            } else if (action == "wait") {
+                uint32_t ms = step.value("ms", 100u);
+                runtime.tick(ms);
+                std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+
+            } else {
+                result.error = "unknown action: " + action;
+                return result;
+            }
+        } catch (const std::exception& e) {
+            result.error = std::string("step error (") + action + "): " + e.what();
+            return result;
+        }
+
+        ++result.steps_run;
+
+        // Inter-step delay
+        const uint32_t delay = step.value("delay_ms", default_delay);
+        if (delay > 0) {
+            runtime.tick(delay);
+            std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+        }
+    }
+
+    result.ok = true;
+    return result;
+}
+
+}  // namespace seedsigner::lvgl


### PR DESCRIPTION
## Summary

Adds a JSON-based scenario loader and replay system for the desktop runner (#80).

### Changes
- **`ScenarioRunner`** class (`src/desktop/ScenarioRunner.cpp`, `include/.../ScenarioRunner.hpp`): parses a JSON scenario file describing a sequence of LVGL input events (key presses, delays) and replays them against the desktop simulator.
- **Example scenario** (`examples/scenarios/main_menu_walk.json`): demonstrates navigating the main menu.
- **`host_desktop_demo.cpp`** updated with `--scenario <path>` CLI flag to launch a scenario replay session.
- Graceful error handling for missing/invalid scenario files.

### Testing
- Default build ✅
- Desktop build ✅
- `ctest` 2/2 pass ✅
- Scenario replay example verified ✅
- Invalid scenario path handled gracefully ✅

### Known Gap
No dedicated unit test for the ScenarioRunner JSON parser. The parser is simple (nlohmann/json loop) and exercised manually. A dedicated test can be added later if needed.

Closes #80