### PR TITLE
feat(desktop): scenario-driven validation suite covering all screen families

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ compile_commands.json
 screenshots/
 screenshots_diff/
 screenshot_diff_report.json
+scenarios/out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,14 @@ if(BUILD_HOST_DESKTOP)
   )
   target_link_libraries(host_desktop_demo PRIVATE seedsigner_lvgl ${SDL2_LIBRARIES} nlohmann_json::nlohmann_json)
   target_compile_options(host_desktop_demo PRIVATE ${SDL2_CFLAGS_OTHER})
+
+  # --- Scenario validation suite (headless) ---
+  add_executable(scenario_suite_runner
+    tests/scenario_suite_runner.cpp
+    src/desktop/ScenarioRunner.cpp
+  )
+  target_link_libraries(scenario_suite_runner PRIVATE seedsigner_lvgl nlohmann_json::nlohmann_json)
+  target_compile_definitions(scenario_suite_runner PRIVATE SOURCE_ROOT="${CMAKE_SOURCE_DIR}")
 endif()
 
 if(BUILD_TESTING)
@@ -129,4 +137,13 @@ if(BUILD_TESTING)
   )
   target_link_libraries(input_profile_tests PRIVATE seedsigner_lvgl)
   add_test(NAME input_profile_tests COMMAND input_profile_tests)
+
+  # Scenario suite as a test target (requires BUILD_HOST_DESKTOP for nlohmann_json)
+  if(BUILD_HOST_DESKTOP)
+    add_test(NAME scenario_suite
+      COMMAND scenario_suite_runner
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+    set_tests_properties(scenario_suite PROPERTIES
+      ENVIRONMENT "SCENARIO_DIR=${CMAKE_SOURCE_DIR}/scenarios;SCENARIO_OUT_DIR=${CMAKE_BINARY_DIR}/scenario_out")
+  endif()
 endif()

--- a/docs/scenario-suite.md
+++ b/docs/scenario-suite.md
@@ -1,0 +1,62 @@
+# Scenario-Driven Validation Suite
+
+Headless JSON scenarios that exercise every screen family through the `ScenarioRunner`.
+
+## What It Does
+
+Each scenario is a JSON file that drives `activate` / `input` / `screenshot` / `wait` steps against a headless `UiRuntime`. The suite runner forks per scenario to keep LVGL state clean.
+
+## Screen Families Covered
+
+| # | Scenario | Screen |
+|---|----------|--------|
+| 01 | `01_menu_navigation.json` | MenuListScreen |
+| 02 | `02_settings_selection.json` | SettingsSelectionScreen |
+| 03 | `03_warning.json` | WarningScreen |
+| 04 | `04_error.json` | ErrorScreen |
+| 05 | `05_dire_warning.json` | DireWarningScreen |
+| 06 | `06_result.json` | ResultScreen |
+| 07 | `07_qr_display.json` | QRDisplayScreen |
+| 08 | `08_keyboard.json` | KeyboardScreen |
+| 09 | `09_seed_words.json` | SeedWordsScreen |
+| 10 | `10_psbt_overview.json` | PSBTOverviewScreen |
+| 11 | `11_startup_splash.json` | StartupSplashScreen |
+
+## Build & Run
+
+```bash
+cmake -S . -B build-suite -DBUILD_HOST_DESKTOP=ON
+cmake --build build-suite --target scenario_suite_runner
+
+# Run all scenarios (from repo root)
+./build-suite/scenario_suite_runner
+
+# Or via CTest
+cd build-suite && ctest -R scenario_suite
+```
+
+Screenshots land in `scenarios/out/` (or `SCENARIO_OUT_DIR` if set).
+
+## Scenario JSON Schema
+
+```json
+{
+  "default_delay_ms": 50,
+  "steps": [
+    { "action": "activate", "route": "suite.menu", "args": { ... } },
+    { "action": "input", "key": "Down" },
+    { "action": "screenshot", "path": "out/menu.png" },
+    { "action": "wait", "ms": 100 }
+  ]
+}
+```
+
+Actions: `activate`, `input`, `screenshot`, `wait`.  
+Keys: `Up`, `Down`, `Left`, `Right`, `Press`, `Back`.
+
+## Adding a Scenario
+
+1. Create `scenarios/NN_name.json` following the schema above
+2. Use `suite.*` route prefix (registered in `tests/scenario_suite_runner.cpp`)
+3. Add any new routes to `register_suite_routes()` in the runner
+4. Run the suite — your scenario is picked up automatically

--- a/scenarios/01_menu_navigation.json
+++ b/scenarios/01_menu_navigation.json
@@ -1,0 +1,17 @@
+{
+  "_doc": "Navigate main menu, scroll through items, verify no crash.",
+  "default_delay_ms": 50,
+  "steps": [
+    { "action": "activate", "route": "suite.menu",
+      "args": {
+        "title": "SeedSigner",
+        "items": "scan|Scan QR|Point camera at a QR code|chevron\nseeds|Seeds|Load or generate a seed|chevron\ntools|Tools|Signing tools and utilities|chevron\nsettings|Settings|Device configuration|chevron"
+      }},
+    { "action": "screenshot", "path": "scenarios/out/01_menu_initial.png" },
+    { "action": "input", "key": "Down" },
+    { "action": "input", "key": "Down" },
+    { "action": "screenshot", "path": "scenarios/out/01_menu_highlight_tools.png" },
+    { "action": "input", "key": "Up" },
+    { "action": "screenshot", "path": "scenarios/out/01_menu_back_up.png" }
+  ]
+}

--- a/scenarios/02_settings_selection.json
+++ b/scenarios/02_settings_selection.json
@@ -1,0 +1,22 @@
+{
+  "_doc": "Settings selection screen: single-choice language picker.",
+  "default_delay_ms": 50,
+  "steps": [
+    { "action": "activate", "route": "suite.settings",
+      "args": {
+        "title": "Settings",
+        "subtitle": "Language",
+        "section_title": "Display language",
+        "help_text": "Choose one language.",
+        "footer_text": "Press to apply.",
+        "value_type": "single",
+        "default_values": "en",
+        "current_values": "en",
+        "items": "en|English|Default Latin font\nes|Español|Accented glyphs\nfr|Français|Wider Latin coverage",
+        "selected_index": "0"
+      }},
+    { "action": "screenshot", "path": "scenarios/out/02_settings_initial.png" },
+    { "action": "input", "key": "Down" },
+    { "action": "screenshot", "path": "scenarios/out/02_settings_highlight_es.png" }
+  ]
+}

--- a/scenarios/03_warning.json
+++ b/scenarios/03_warning.json
@@ -1,0 +1,9 @@
+{
+  "_doc": "Warning screen with acknowledgement button.",
+  "default_delay_ms": 50,
+  "steps": [
+    { "action": "activate", "route": "suite.warning",
+      "args": { "title": "Warning", "body": "This seed was generated on this device.\nVerify the words carefully.", "button_text": "I Understand" }},
+    { "action": "screenshot", "path": "scenarios/out/03_warning.png" }
+  ]
+}

--- a/scenarios/04_error.json
+++ b/scenarios/04_error.json
@@ -1,0 +1,9 @@
+{
+  "_doc": "Error screen with retry button.",
+  "default_delay_ms": 50,
+  "steps": [
+    { "action": "activate", "route": "suite.error",
+      "args": { "title": "Scan Failed", "body": "Could not decode QR code.\nTry again with better lighting.", "button_text": "Retry" }},
+    { "action": "screenshot", "path": "scenarios/out/04_error.png" }
+  ]
+}

--- a/scenarios/05_dire_warning.json
+++ b/scenarios/05_dire_warning.json
@@ -1,0 +1,9 @@
+{
+  "_doc": "Dire warning screen for destructive actions.",
+  "default_delay_ms": 50,
+  "steps": [
+    { "action": "activate", "route": "suite.dire_warning",
+      "args": { "title": "DANGER", "body": "You are about to sign a transaction\nthat sends ALL funds to a single address.\n\nThis cannot be undone.", "button_text": "I Accept the Risk" }},
+    { "action": "screenshot", "path": "scenarios/out/05_dire_warning.png" }
+  ]
+}

--- a/scenarios/06_result.json
+++ b/scenarios/06_result.json
@@ -1,0 +1,9 @@
+{
+  "_doc": "Result screen showing success.",
+  "default_delay_ms": 50,
+  "steps": [
+    { "action": "activate", "route": "suite.result",
+      "args": { "title": "Signed Successfully", "body": "Transaction signed and QR\ndisplayed for broadcast.", "continue_action": "done" }},
+    { "action": "screenshot", "path": "scenarios/out/06_result.png" }
+  ]
+}

--- a/scenarios/07_qr_display.json
+++ b/scenarios/07_qr_display.json
@@ -1,0 +1,9 @@
+{
+  "_doc": "QR code display screen.",
+  "default_delay_ms": 50,
+  "steps": [
+    { "action": "activate", "route": "suite.qr",
+      "args": { "qr_data": "bitcoin:bc1qexampleaddress123456789?amount=0.001", "title": "Signed PSBT", "brightness": "100" }},
+    { "action": "screenshot", "path": "scenarios/out/07_qr_display.png" }
+  ]
+}

--- a/scenarios/08_keyboard.json
+++ b/scenarios/08_keyboard.json
@@ -1,0 +1,12 @@
+{
+  "_doc": "Keyboard input screen.",
+  "default_delay_ms": 50,
+  "steps": [
+    { "action": "activate", "route": "suite.keyboard",
+      "args": { "layout": "lowercase", "placeholder": "Enter passphrase", "max_length": "64" }},
+    { "action": "screenshot", "path": "scenarios/out/08_keyboard.png" },
+    { "action": "input", "key": "Right" },
+    { "action": "input", "key": "Down" },
+    { "action": "screenshot", "path": "scenarios/out/08_keyboard_navigated.png" }
+  ]
+}

--- a/scenarios/09_seed_words.json
+++ b/scenarios/09_seed_words.json
@@ -1,0 +1,9 @@
+{
+  "_doc": "Seed words display screen.",
+  "default_delay_ms": 50,
+  "steps": [
+    { "action": "activate", "route": "suite.seed_words",
+      "args": { "words": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about", "title": "Seed Phrase", "words_per_page": "6" }},
+    { "action": "screenshot", "path": "scenarios/out/09_seed_words_p1.png" }
+  ]
+}

--- a/scenarios/10_psbt_overview.json
+++ b/scenarios/10_psbt_overview.json
@@ -1,0 +1,17 @@
+{
+  "_doc": "PSBT overview screen.",
+  "default_delay_ms": 50,
+  "steps": [
+    { "action": "activate", "route": "suite.psbt_overview",
+      "args": {
+        "total_amount": "0.005 BTC",
+        "fee_amount": "0.0001 BTC",
+        "change_amount": "0.0049 BTC",
+        "inputs_count": "2",
+        "outputs_count": "2",
+        "network": "mainnet",
+        "recipient_label": "bc1qexample..."
+      }},
+    { "action": "screenshot", "path": "scenarios/out/10_psbt_overview.png" }
+  ]
+}

--- a/scenarios/11_startup_splash.json
+++ b/scenarios/11_startup_splash.json
@@ -1,0 +1,8 @@
+{
+  "_doc": "Startup splash screen.",
+  "default_delay_ms": 50,
+  "steps": [
+    { "action": "activate", "route": "suite.splash", "args": {} },
+    { "action": "screenshot", "path": "scenarios/out/11_splash.png" }
+  ]
+}

--- a/tests/scenario_suite_runner.cpp
+++ b/tests/scenario_suite_runner.cpp
@@ -1,0 +1,145 @@
+// scenario_suite_runner — headless scenario validation suite.
+//
+// Registers all screen-family routes, then runs every JSON scenario
+// found in SCENARIO_DIR.  Each scenario drives activate/input/screenshot
+// steps via ScenarioRunner.  Exit code 0 = all pass, 1 = any failure.
+//
+// Build:
+//   cmake -S . -B build-suite -DBUILD_HOST_DESKTOP=ON
+//   cmake --build build-suite --target scenario_suite_runner
+//
+// Run:
+//   SCENARIO_OUT_DIR=/tmp/scenario-out ./build-suite/scenario_suite_runner
+
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+#include <vector>
+#include <algorithm>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <lvgl.h>
+
+#include "seedsigner_lvgl/desktop/ScenarioRunner.hpp"
+#include "seedsigner_lvgl/runtime/UiRuntime.hpp"
+#include "seedsigner_lvgl/screen/ScreenRegistry.hpp"
+#include "seedsigner_lvgl/contracts/RouteDescriptor.hpp"
+#include "seedsigner_lvgl/screens/MenuListScreen.hpp"
+#include "seedsigner_lvgl/screens/SettingsSelectionScreen.hpp"
+#include "seedsigner_lvgl/screens/WarningScreen.hpp"
+#include "seedsigner_lvgl/screens/ErrorScreen.hpp"
+#include "seedsigner_lvgl/screens/DireWarningScreen.hpp"
+#include "seedsigner_lvgl/screens/ResultScreen.hpp"
+#include "seedsigner_lvgl/screens/QRDisplayScreen.hpp"
+#include "seedsigner_lvgl/screens/KeyboardScreen.hpp"
+#include "seedsigner_lvgl/screens/SeedWordsScreen.hpp"
+#include "seedsigner_lvgl/screens/PSBTOverviewScreen.hpp"
+#include "seedsigner_lvgl/screens/StartupSplashScreen.hpp"
+
+using namespace seedsigner::lvgl;
+
+// Register all suite routes — mirrors the screen families used in scenarios.
+static void register_suite_routes(ScreenRegistry& reg) {
+    reg.register_route(RouteId{"suite.menu"},
+        []() -> std::unique_ptr<Screen> { return std::make_unique<MenuListScreen>(); });
+    reg.register_route(RouteId{"suite.settings"},
+        []() -> std::unique_ptr<Screen> { return std::make_unique<SettingsSelectionScreen>(); });
+    reg.register_route(RouteId{"suite.warning"},
+        []() -> std::unique_ptr<Screen> { return std::make_unique<WarningScreen>(); });
+    reg.register_route(RouteId{"suite.error"},
+        []() -> std::unique_ptr<Screen> { return std::make_unique<ErrorScreen>(); });
+    reg.register_route(RouteId{"suite.dire_warning"},
+        []() -> std::unique_ptr<Screen> { return std::make_unique<DireWarningScreen>(); });
+    reg.register_route(RouteId{"suite.result"},
+        []() -> std::unique_ptr<Screen> { return std::make_unique<ResultScreen>(); });
+    reg.register_route(RouteId{"suite.qr"},
+        []() -> std::unique_ptr<Screen> { return std::make_unique<QRDisplayScreen>(); });
+    reg.register_route(RouteId{"suite.keyboard"},
+        []() -> std::unique_ptr<Screen> { return std::make_unique<KeyboardScreen>(); });
+    reg.register_route(RouteId{"suite.seed_words"},
+        []() -> std::unique_ptr<Screen> { return std::make_unique<SeedWordsScreen>(); });
+    reg.register_route(RouteId{"suite.psbt_overview"},
+        []() -> std::unique_ptr<Screen> { return std::make_unique<PSBTOverviewScreen>(); });
+    reg.register_route(RouteId{"suite.splash"},
+        []() -> std::unique_ptr<Screen> { return std::make_unique<StartupSplashScreen>(); });
+}
+
+// Discover scenario JSON files, sorted alphabetically.
+static std::vector<std::string> find_scenarios(const std::string& dir) {
+    std::vector<std::string> paths;
+    for (const auto& entry : std::filesystem::directory_iterator(dir)) {
+        if (entry.is_regular_file() && entry.path().extension() == ".json") {
+            paths.push_back(entry.path().string());
+        }
+    }
+    std::sort(paths.begin(), paths.end());
+    return paths;
+}
+
+int main(int argc, char** argv) {
+    // Scenario dir defaults to SCENARIO_DIR env or "scenarios" relative to CWD.
+    const char* scenario_dir_env = std::getenv("SCENARIO_DIR");
+    const char* out_dir_env = std::getenv("SCENARIO_OUT_DIR");
+    std::string scenario_dir = scenario_dir_env ? scenario_dir_env : "scenarios";
+    std::string out_dir = out_dir_env ? out_dir_env : "scenarios/out";
+
+    std::printf("=== SeedSigner-LVGL Scenario Validation Suite ===\n");
+    std::printf("Scenario dir: %s\n", scenario_dir.c_str());
+    std::printf("Output dir:   %s\n\n", out_dir.c_str());
+
+    // Create output directory.
+    std::filesystem::create_directories(out_dir);
+
+    auto scenarios = find_scenarios(scenario_dir);
+    if (scenarios.empty()) {
+        std::fprintf(stderr, "No .json scenarios found in %s\n", scenario_dir.c_str());
+        return 1;
+    }
+
+    std::printf("Found %zu scenarios:\n", scenarios.size());
+    for (const auto& s : scenarios) std::printf("  %s\n", s.c_str());
+    std::printf("\n");
+
+    int pass = 0, fail = 0;
+    for (const auto& scenario_path : scenarios) {
+        std::string name = std::filesystem::path(scenario_path).filename().string();
+
+        // Fork to isolate LVGL state between scenarios.
+        pid_t pid = fork();
+        if (pid == 0) {
+            // Child process.
+            lv_init();
+            UiRuntime rt(RuntimeConfig{.width = 240, .height = 320});
+            rt.init();
+            register_suite_routes(rt.screen_registry());
+
+            auto result = ScenarioRunner::load_and_run(scenario_path, rt, 240, 320);
+            if (result.ok) {
+                std::printf("  [PASS] %s (%d steps)\n", name.c_str(), result.steps_run);
+                _exit(0);
+            } else {
+                std::fprintf(stderr, "  [FAIL] %s (step %d): %s\n",
+                             name.c_str(), result.steps_run, result.error.c_str());
+                _exit(1);
+            }
+        } else if (pid > 0) {
+            int status;
+            waitpid(pid, &status, 0);
+            if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+                ++pass;
+            } else {
+                ++fail;
+            }
+        } else {
+            std::fprintf(stderr, "  [FAIL] %s: fork error\n", name.c_str());
+            ++fail;
+        }
+    }
+
+    std::printf("\n=== Results: %d passed, %d failed, %zu total ===\n",
+                pass, fail, scenarios.size());
+    return fail > 0 ? 1 : 0;
+}


### PR DESCRIPTION
Closes #87

Adds a scenario-driven validation suite that exercises all major screen families (Main, Seed, Settings, Tools, Scan, etc.) with 11 scenarios. Includes screenshot generation and automated pass/fail reporting.

Validation: build OK (BUILD_HOST_DESKTOP=ON), 11/11 scenarios pass, screenshots generated.