### PR TITLE
fix(#109): SDL partial-area corruption — separate draw buffer + persistent texture

### DIFF
--- a/include/seedsigner_lvgl/platform/SdlDisplay.hpp
+++ b/include/seedsigner_lvgl/platform/SdlDisplay.hpp
@@ -20,6 +20,7 @@
 
 #include <lvgl.h>
 
+struct SDL_Texture;
 struct SDL_Window;
 struct SDL_Renderer;
 union SDL_Event;
@@ -109,6 +110,11 @@ private:
     // SDL state — opaque pointers; lifetime managed in .cpp via RAII.
     struct SdlState;
     std::unique_ptr<SdlState> sdl_;
+
+    // Persistent texture — created once, updated each frame via SDL_UpdateTexture.
+    // Avoids per-frame allocation churn that causes corruption on some SDL backends.
+    SDL_Texture* texture_{nullptr};
+    std::vector<std::uint32_t> argb_buffer_;  ///< Expanded ARGB8888 pixel buffer
 
     QuitCallback quit_callback_;
     bool quit_requested_{false};

--- a/include/seedsigner_lvgl/platform/SdlDisplay.hpp
+++ b/include/seedsigner_lvgl/platform/SdlDisplay.hpp
@@ -105,7 +105,8 @@ private:
     lv_disp_draw_buf_t draw_buffer_{};
     lv_disp_drv_t display_driver_{};
     lv_disp_t* display_{nullptr};  ///< LVGL display handle (needed for removal on profile switch)
-    std::vector<lv_color_t> framebuffer_;
+    std::vector<lv_color_t> draw_buf_;     ///< LVGL render scratch (partial-area, linear)
+    std::vector<lv_color_t> framebuffer_;  ///< Full-frame buffer (always coherent)
 
     // SDL state — opaque pointers; lifetime managed in .cpp via RAII.
     struct SdlState;

--- a/src/platform/SdlDisplay.cpp
+++ b/src/platform/SdlDisplay.cpp
@@ -5,6 +5,7 @@
 #include "seedsigner_lvgl/runtime/InputEvent.hpp"
 
 #include <cstdio>
+#include <cstring>
 
 // SDL2 headers — keep after project headers to avoid macro collisions.
 #include <SDL.h>
@@ -34,6 +35,7 @@ SdlDisplay::SdlDisplay(std::uint32_t width, std::uint32_t height, std::uint32_t 
     : width_(width)
     , height_(height)
     , pixel_scale_(pixel_scale)
+    , draw_buf_(static_cast<std::size_t>(width) * 40)          // 40-row LVGL render scratch
     , framebuffer_(static_cast<std::size_t>(width) * height)
     , argb_buffer_(static_cast<std::size_t>(width) * height)
     , sdl_(std::make_unique<SdlState>())
@@ -45,9 +47,10 @@ SdlDisplay::SdlDisplay(std::uint32_t width, std::uint32_t height, std::uint32_t 
 
     create_sdl_window();
 
-    // Register an LVGL display driver backed by our framebuffer.
-    lv_disp_draw_buf_init(&draw_buffer_, framebuffer_.data(), nullptr,
-                          static_cast<uint32_t>(framebuffer_.size()));
+    // Use a small render scratch for LVGL — flush_cb copies partial areas
+    // into the correct position in the full framebuffer.
+    lv_disp_draw_buf_init(&draw_buffer_, draw_buf_.data(), nullptr,
+                          static_cast<uint32_t>(draw_buf_.size()));
     lv_disp_drv_init(&display_driver_);
     display_driver_.hor_res  = width_;
     display_driver_.ver_res  = height_;
@@ -63,12 +66,20 @@ SdlDisplay::~SdlDisplay() = default;
 // LVGL flush callback
 // -------------------------------------------------------------------------- //
 
-void SdlDisplay::flush_cb(lv_disp_drv_t* disp_drv, const lv_area_t* area, lv_color_t* /*color_p*/) {
+void SdlDisplay::flush_cb(lv_disp_drv_t* disp_drv, const lv_area_t* area, lv_color_t* color_p) {
     auto* self = static_cast<SdlDisplay*>(disp_drv->user_data);
     if (self) {
         ++self->flush_count_;
-        // We always blit the full framebuffer — partial area blitting is a
-        // future optimisation that isn't worth the complexity for a demo.
+
+        // Copy the partial render from LVGL's linear scratch buffer into the
+        // correct position in the full framebuffer.
+        const int area_w = area->x2 - area->x1 + 1;
+        for (int y = area->y1; y <= area->y2; ++y) {
+            std::memcpy(&self->framebuffer_[static_cast<std::size_t>(y) * self->width_ + area->x1],
+                        color_p,
+                        static_cast<std::size_t>(area_w) * sizeof(lv_color_t));
+            color_p += area_w;
+        }
         self->blit_framebuffer();
     }
     lv_disp_flush_ready(disp_drv);
@@ -160,7 +171,6 @@ void SdlDisplay::set_quit_callback(QuitCallback cb) {
 }
 
 void SdlDisplay::refresh() {
-    lv_refr_now(nullptr);
     lv_timer_handler();
     blit_framebuffer();
 }
@@ -292,6 +302,7 @@ bool SdlDisplay::switch_resolution(std::uint32_t new_width, std::uint32_t new_he
     // 2. Update dimensions and reallocate framebuffer.
     width_  = new_width;
     height_ = new_height;
+    draw_buf_.assign(static_cast<std::size_t>(width_) * 40, lv_color_t{});
     framebuffer_.assign(static_cast<std::size_t>(width_) * height_, lv_color_t{});
     argb_buffer_.assign(static_cast<std::size_t>(width_) * height_, 0);
 
@@ -300,8 +311,8 @@ bool SdlDisplay::switch_resolution(std::uint32_t new_width, std::uint32_t new_he
     if (!sdl_->window || !sdl_->renderer) return false;
 
     // 4. Re-register the LVGL display driver with the new resolution.
-    lv_disp_draw_buf_init(&draw_buffer_, framebuffer_.data(), nullptr,
-                          static_cast<uint32_t>(framebuffer_.size()));
+    lv_disp_draw_buf_init(&draw_buffer_, draw_buf_.data(), nullptr,
+                          static_cast<uint32_t>(draw_buf_.size()));
     lv_disp_drv_init(&display_driver_);
     display_driver_.hor_res  = width_;
     display_driver_.ver_res  = height_;

--- a/src/platform/SdlDisplay.cpp
+++ b/src/platform/SdlDisplay.cpp
@@ -35,6 +35,7 @@ SdlDisplay::SdlDisplay(std::uint32_t width, std::uint32_t height, std::uint32_t 
     , height_(height)
     , pixel_scale_(pixel_scale)
     , framebuffer_(static_cast<std::size_t>(width) * height)
+    , argb_buffer_(static_cast<std::size_t>(width) * height)
     , sdl_(std::make_unique<SdlState>())
 {
     if (SDL_Init(SDL_INIT_VIDEO) != 0) {
@@ -80,33 +81,43 @@ void SdlDisplay::flush_cb(lv_disp_drv_t* disp_drv, const lv_area_t* area, lv_col
 void SdlDisplay::blit_framebuffer() {
     if (!sdl_->renderer) return;
 
-    // LV_COLOR_FORMAT is RGB565 (16-bit) by default on v8.3.  We expand to
-    // RGB888 for SDL's surface.
-    SDL_Surface* surf = SDL_CreateRGBSurfaceWithFormat(
-        0, static_cast<int>(width_), static_cast<int>(height_), 32,
-        SDL_PIXELFORMAT_RGBX8888);
-    if (!surf) return;
+    // Lazily create (or recreate after resolution switch) the persistent texture.
+    if (!texture_) {
+        texture_ = SDL_CreateTexture(
+            sdl_->renderer,
+            SDL_PIXELFORMAT_ARGB8888,
+            SDL_TEXTUREACCESS_STREAMING,
+            static_cast<int>(width_),
+            static_cast<int>(height_));
+        if (!texture_) {
+            std::fprintf(stderr, "[SdlDisplay] SDL_CreateTexture failed: %s\n", SDL_GetError());
+            return;
+        }
+    }
 
-    auto* px = static_cast<std::uint32_t*>(surf->pixels);
+    // Expand RGB565 framebuffer → ARGB8888 intermediate buffer.
     for (std::size_t i = 0; i < framebuffer_.size(); ++i) {
         const lv_color_t c = framebuffer_[i];
-        // lv_color_t is a uint16_t in RGB565.  Expand channels.
         const auto r = static_cast<std::uint32_t>((c.full >> 11) & 0x1F) * 255 / 31;
         const auto g = static_cast<std::uint32_t>((c.full >>  5) & 0x3F) * 255 / 63;
         const auto b = static_cast<std::uint32_t>( c.full        & 0x1F) * 255 / 31;
-        px[i] = (r << 24) | (g << 16) | (b << 8) | 0xFF;
+        argb_buffer_[i] = (0xFFu << 24) | (r << 16) | (g << 8) | b;
     }
 
-    SDL_Texture* tex = SDL_CreateTextureFromSurface(sdl_->renderer, surf);
-    if (tex) {
-        int win_w, win_h;
-        SDL_GetRendererOutputSize(sdl_->renderer, &win_w, &win_h);
-        SDL_Rect dst{0, 0, win_w, win_h};
-        SDL_RenderCopy(sdl_->renderer, tex, nullptr, &dst);
-        SDL_RenderPresent(sdl_->renderer);
-        SDL_DestroyTexture(tex);
+    // Upload full buffer to the persistent texture.
+    // pitch = width * 4 bytes (ARGB8888), guaranteed correct for our linear buffer.
+    const int pitch = static_cast<int>(width_) * 4;
+    if (SDL_UpdateTexture(texture_, nullptr, argb_buffer_.data(), pitch) != 0) {
+        std::fprintf(stderr, "[SdlDisplay] SDL_UpdateTexture failed: %s\n", SDL_GetError());
+        return;
     }
-    SDL_FreeSurface(surf);
+
+    int win_w, win_h;
+    SDL_GetRendererOutputSize(sdl_->renderer, &win_w, &win_h);
+    SDL_Rect dst{0, 0, win_w, win_h};
+    SDL_RenderClear(sdl_->renderer);
+    SDL_RenderCopy(sdl_->renderer, texture_, nullptr, &dst);
+    SDL_RenderPresent(sdl_->renderer);
 }
 
 // -------------------------------------------------------------------------- //
@@ -236,7 +247,8 @@ void SdlDisplay::pointer_read_cb(lv_indev_drv_t* drv, lv_indev_data_t* data) {
 // -------------------------------------------------------------------------- //
 
 void SdlDisplay::create_sdl_window() {
-    // Destroy previous window/renderer if any.
+    // Destroy previous texture/window/renderer if any.
+    if (texture_)      { SDL_DestroyTexture(texture_);        texture_       = nullptr; }
     if (sdl_->renderer) { SDL_DestroyRenderer(sdl_->renderer); sdl_->renderer = nullptr; }
     if (sdl_->window)   { SDL_DestroyWindow(sdl_->window);     sdl_->window   = nullptr; }
 
@@ -281,8 +293,9 @@ bool SdlDisplay::switch_resolution(std::uint32_t new_width, std::uint32_t new_he
     width_  = new_width;
     height_ = new_height;
     framebuffer_.assign(static_cast<std::size_t>(width_) * height_, lv_color_t{});
+    argb_buffer_.assign(static_cast<std::size_t>(width_) * height_, 0);
 
-    // 3. Recreate SDL window at new size.
+    // 3. Recreate SDL window at new size (also resets texture_).
     create_sdl_window();
     if (!sdl_->window || !sdl_->renderer) return false;
 


### PR DESCRIPTION
## Summary

Fixes SDL desktop render corruption that persisted after #108.

Two commits:
- **0232d9e** — Persistent SDL texture: eliminate per-frame `SDL_CreateTexture`/`SDL_DestroyTexture` churn that caused flicker and resource leaks.
- **0de047f** — Separate LVGL draw buffer from framebuffer: the root cause — LVGL renders partial areas (not full frames), so sharing the draw buffer with the display framebuffer caused stale/corrupt pixels in unflushed regions.

## Testing
- Confirmed working on real desktop by @alvroblaw — no corruption after menu interaction, smooth rendering.

Closes #109
Relates to #108