### PR TITLE
feat(#97): SeedWordsScreen parity — 2-column grid, paged display, warning

### DIFF
--- a/include/seedsigner_lvgl/screens/SeedWordsScreen.hpp
+++ b/include/seedsigner_lvgl/screens/SeedWordsScreen.hpp
@@ -18,7 +18,7 @@ public:
 
 private:
     void update_page();
-    void create_word_chip(lv_obj_t* parent, int index, const std::string& word);
+    void create_word_chip(lv_obj_t* parent, int index, const std::string& word, int width);
     void apply_warning_styling(lv_obj_t* obj);
     void emit_page_changed();
     void emit_back_requested();

--- a/src/screens/SeedWordsScreen.cpp
+++ b/src/screens/SeedWordsScreen.cpp
@@ -6,6 +6,7 @@
 
 #include <lvgl.h>
 #include <algorithm>
+#include <cstdio>
 #include <string>
 
 namespace seedsigner::lvgl {
@@ -16,12 +17,19 @@ constexpr const char* kBackRequestedAction = "back_requested";
 constexpr const char* kWordSelectedAction = "word_selected";
 constexpr const char* kSeedWordsComponent = "seed_words_screen";
 
-constexpr const char* kDefaultWarningText = "Never digitize these words. Store this offline.";
+constexpr const char* kDefaultWarningText = "Do not digitize these words. Write them down and store offline.";
 constexpr const char* kDefaultTitle = "Seed Words";
 
-static int chip_width() { return profile::active().chip_width; }
-constexpr int kChipHeight = theme::spacing::CHIP_HEIGHT;
-constexpr int kChipMargin = theme::spacing::CHIP_MARGIN;
+// SeedSigner-style: 2-column grid, each chip shows "N. word"
+constexpr int kColumns = 2;
+constexpr int kChipH = 28;          // compact row height
+constexpr int kGridGap = 4;         // gap between chips
+
+int chip_width_px() {
+    // Subtract padding and gap from screen width
+    // SCREEN_PADDING on each side + gap between columns
+    return (profile::active().width - 2 * theme::spacing::SCREEN_PADDING - kGridGap) / kColumns;
+}
 
 const char* value_or(const PropertyMap& values, const char* key, const char* fallback) {
     const auto it = values.find(key);
@@ -33,125 +41,112 @@ const char* value_or(const PropertyMap& values, const char* key, const char* fal
 void SeedWordsScreen::create(const ScreenContext& context, const RouteDescriptor& route) {
     context_ = context;
     params_ = parse_seed_words_params(route.args);
-    
+
+    // Use profile words_per_page if not overridden
+    if (params_.words_per_page <= 0) {
+        params_.words_per_page = profile::active().words_per_page;
+    }
+
     // Calculate total pages
-    total_pages_ = (params_.words.size() + params_.words_per_page - 1) / params_.words_per_page;
+    total_pages_ = (static_cast<int>(params_.words.size()) + params_.words_per_page - 1) / params_.words_per_page;
     current_page_ = 0;
-    
-    // Initialize styles if needed
+
+    // Initialize styles
     if (!styles_initialized_) {
+        // Normal chip: dark surface, subtle border
         lv_style_init(&chip_style_);
-        lv_style_set_radius(&chip_style_, seedsigner::lvgl::theme::spacing::CHIP_RADIUS);
-        lv_style_set_bg_opa(&chip_style_, LV_OPA_20);
-        lv_style_set_bg_color(&chip_style_, seedsigner::lvgl::theme::active_theme().SURFACE_MEDIUM);
+        lv_style_set_radius(&chip_style_, theme::spacing::CHIP_RADIUS);
+        lv_style_set_bg_opa(&chip_style_, LV_OPA_COVER);
+        lv_style_set_bg_color(&chip_style_, theme::active_theme().SURFACE_MEDIUM);
         lv_style_set_border_width(&chip_style_, 1);
-        lv_style_set_border_color(&chip_style_, seedsigner::lvgl::theme::active_theme().BORDER);
-        lv_style_set_pad_all(&chip_style_, 6);
-        lv_style_set_text_color(&chip_style_, seedsigner::lvgl::theme::active_theme().TEXT_PRIMARY);
-        
+        lv_style_set_border_color(&chip_style_, theme::active_theme().BORDER);
+        lv_style_set_pad_ver(&chip_style_, 4);
+        lv_style_set_pad_hor(&chip_style_, 6);
+        lv_style_set_text_color(&chip_style_, theme::active_theme().TEXT_PRIMARY);
+        lv_style_set_text_font(&chip_style_, theme::typography::BODY);
+
+        // Warning chip (unused for now, kept for future highlight)
         lv_style_init(&warning_chip_style_);
-        lv_style_set_radius(&warning_chip_style_, seedsigner::lvgl::theme::spacing::CHIP_RADIUS);
+        lv_style_set_radius(&warning_chip_style_, theme::spacing::CHIP_RADIUS);
         lv_style_set_bg_opa(&warning_chip_style_, LV_OPA_20);
-        lv_style_set_bg_color(&warning_chip_style_, seedsigner::lvgl::theme::active_theme().PRIMARY);
+        lv_style_set_bg_color(&warning_chip_style_, theme::active_theme().PRIMARY);
         lv_style_set_border_width(&warning_chip_style_, 2);
-        lv_style_set_border_color(&warning_chip_style_, seedsigner::lvgl::theme::active_theme().PRIMARY);
-        lv_style_set_pad_all(&warning_chip_style_, 6);
-        lv_style_set_text_color(&warning_chip_style_, seedsigner::lvgl::theme::active_theme().TEXT_PRIMARY);
+        lv_style_set_border_color(&warning_chip_style_, theme::active_theme().PRIMARY);
+        lv_style_set_pad_ver(&warning_chip_style_, 4);
+        lv_style_set_pad_hor(&warning_chip_style_, 6);
+        lv_style_set_text_color(&warning_chip_style_, theme::active_theme().TEXT_PRIMARY);
+        lv_style_set_text_font(&warning_chip_style_, theme::typography::BODY);
+
         styles_initialized_ = true;
     }
-    
-    // Create container
-    // Root container: column with top nav bar and content area
+
+    // Root container
     container_ = lv_obj_create(context.root);
     lv_obj_set_size(container_, lv_pct(100), lv_pct(100));
     lv_obj_set_style_pad_all(container_, 0, 0);
+    lv_obj_set_style_bg_opa(container_, LV_OPA_COVER, 0);
+    lv_obj_set_style_bg_color(container_, theme::active_theme().SURFACE_DARK, 0);
+    lv_obj_set_style_border_width(container_, 0, 0);
     lv_obj_set_flex_flow(container_, LV_FLEX_FLOW_COLUMN);
-    lv_obj_set_flex_align(container_, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
 
     // Top navigation bar
     top_nav_bar_ = std::make_unique<TopNavBar>(context);
     TopNavBarConfig nav_config;
     nav_config.title = params_.title.value_or(kDefaultTitle);
     nav_config.show_back = true;
-    nav_config.show_home = false;
-    nav_config.show_cancel = false;
     top_nav_bar_->set_config(nav_config);
     top_nav_bar_->attach(container_);
 
-    // Content container (scrollable area below the nav bar)
+    // Content container
     content_container_ = lv_obj_create(container_);
     lv_obj_set_size(content_container_, lv_pct(100), lv_pct(100));
     lv_obj_set_flex_grow(content_container_, 1);
-    lv_obj_set_scroll_dir(content_container_, LV_DIR_VER);
     lv_obj_set_flex_flow(content_container_, LV_FLEX_FLOW_COLUMN);
     lv_obj_set_flex_align(content_container_, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_pad_all(content_container_, seedsigner::lvgl::theme::spacing::SCREEN_PADDING, 0);
-    
-    // Page indicator
-    page_label_ = lv_label_create(content_container_);
-    lv_obj_set_width(page_label_, lv_pct(100));
-    lv_label_set_text_fmt(page_label_, "Page %d/%d", current_page_ + 1, total_pages_);
-    lv_obj_set_style_text_align(page_label_, LV_TEXT_ALIGN_CENTER, 0);
-    lv_obj_set_style_pad_bottom(page_label_, 8, 0);
-    
-    // Warning text
-    const std::string warning = params_.warning_text.value_or(kDefaultWarningText);
+    lv_obj_set_style_pad_all(content_container_, theme::spacing::SCREEN_PADDING, 0);
+    lv_obj_set_style_pad_row(content_container_, 4, 0);
+    lv_obj_set_style_bg_opa(content_container_, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(content_container_, 0, 0);
+    lv_obj_clear_flag(content_container_, LV_OBJ_FLAG_SCROLLABLE);
+
+    // --- Warning banner ---
     warning_label_ = lv_label_create(content_container_);
     lv_obj_set_width(warning_label_, lv_pct(100));
     lv_label_set_long_mode(warning_label_, LV_LABEL_LONG_WRAP);
-    lv_label_set_text(warning_label_, warning.c_str());
+    lv_label_set_text(warning_label_, params_.warning_text.value_or(kDefaultWarningText).c_str());
     lv_obj_set_style_text_align(warning_label_, LV_TEXT_ALIGN_CENTER, 0);
-    lv_obj_set_style_text_color(warning_label_, seedsigner::lvgl::theme::active_theme().WARNING, 0);
-    lv_obj_set_style_pad_bottom(warning_label_, 10, 0);
-    
-    // Words container (grid)
+    lv_obj_set_style_text_color(warning_label_, theme::active_theme().WARNING, 0);
+    lv_obj_set_style_text_font(warning_label_, theme::typography::CAPTION, 0);
+    lv_obj_set_style_pad_bottom(warning_label_, 6, 0);
+
+    // --- Page indicator ---
+    page_label_ = lv_label_create(content_container_);
+    lv_label_set_text_fmt(page_label_, "%d / %d", current_page_ + 1, total_pages_);
+    lv_obj_set_style_text_color(page_label_, theme::active_theme().TEXT_SECONDARY, 0);
+    lv_obj_set_style_text_font(page_label_, theme::typography::CAPTION, 0);
+    lv_obj_set_style_pad_bottom(page_label_, 4, 0);
+
+    // --- Word grid container ---
     words_container_ = lv_obj_create(content_container_);
-    lv_obj_set_size(words_container_, lv_pct(100), lv_pct(60));
-    lv_obj_set_flex_flow(words_container_, LV_FLEX_FLOW_ROW_WRAP);
-    lv_obj_set_flex_align(words_container_, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_size(words_container_, lv_pct(100), LV_SIZE_CONTENT);
+    lv_obj_set_style_bg_opa(words_container_, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(words_container_, 0, 0);
     lv_obj_set_style_pad_all(words_container_, 0, 0);
-    lv_obj_set_style_pad_gap(words_container_, kChipMargin, 0);
-    
-    // Create chips for current page
+    lv_obj_set_flex_flow(words_container_, LV_FLEX_FLOW_ROW_WRAP);
+    lv_obj_set_flex_align(words_container_, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+    lv_obj_set_style_pad_column(words_container_, kGridGap, 0);
+    lv_obj_set_style_pad_row(words_container_, kGridGap, 0);
+    lv_obj_clear_flag(words_container_, LV_OBJ_FLAG_SCROLLABLE);
+
+    // Populate first page
     update_page();
-    
-    // Navigation buttons (prev/next) if multiple pages
+
+    // --- Nav hint at bottom ---
     if (total_pages_ > 1) {
-        lv_obj_t* button_row = lv_obj_create(content_container_);
-        lv_obj_set_size(button_row, lv_pct(100), 48);
-        lv_obj_set_flex_flow(button_row, LV_FLEX_FLOW_ROW);
-        lv_obj_set_flex_align(button_row, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-        lv_obj_set_style_pad_all(button_row, 0, 0);
-        
-        prev_button_ = lv_btn_create(button_row);
-        lv_obj_set_size(prev_button_, 80, 40);
-        lv_obj_set_style_radius(prev_button_, 8, 0);
-        lv_obj_add_event_cb(prev_button_, [](lv_event_t* e) {
-            auto* screen = static_cast<SeedWordsScreen*>(lv_event_get_user_data(e));
-            if (screen != nullptr && screen->current_page_ > 0) {
-                screen->current_page_--;
-                screen->update_page();
-                screen->emit_page_changed();
-            }
-        }, LV_EVENT_CLICKED, this);
-        lv_obj_t* prev_label = lv_label_create(prev_button_);
-        lv_label_set_text(prev_label, LV_SYMBOL_LEFT " Prev");
-        lv_obj_center(prev_label);
-        
-        next_button_ = lv_btn_create(button_row);
-        lv_obj_set_size(next_button_, 80, 40);
-        lv_obj_set_style_radius(next_button_, 8, 0);
-        lv_obj_add_event_cb(next_button_, [](lv_event_t* e) {
-            auto* screen = static_cast<SeedWordsScreen*>(lv_event_get_user_data(e));
-            if (screen != nullptr && screen->current_page_ < screen->total_pages_ - 1) {
-                screen->current_page_++;
-                screen->update_page();
-                screen->emit_page_changed();
-            }
-        }, LV_EVENT_CLICKED, this);
-        lv_obj_t* next_label = lv_label_create(next_button_);
-        lv_label_set_text(next_label, "Next " LV_SYMBOL_RIGHT);
-        lv_obj_center(next_label);
+        lv_obj_t* hint = lv_label_create(content_container_);
+        lv_label_set_text(hint, LV_SYMBOL_LEFT " Prev             Next " LV_SYMBOL_RIGHT);
+        lv_obj_set_style_text_color(hint, theme::active_theme().TEXT_SECONDARY, 0);
+        lv_obj_set_style_text_font(hint, theme::typography::CAPTION, 0);
     }
 }
 
@@ -173,7 +168,6 @@ void SeedWordsScreen::destroy() {
 }
 
 bool SeedWordsScreen::handle_input(const InputEvent& input) {
-    // Let TopNavBar handle input first (e.g., hardware back button)
     if (top_nav_bar_ && top_nav_bar_->handle_input(input)) {
         return true;
     }
@@ -195,18 +189,13 @@ bool SeedWordsScreen::handle_input(const InputEvent& input) {
                 return true;
             }
             break;
-        case InputKey::Press:
-            // Optionally emit word_selected for focused chip (not implemented yet)
-            // For now, treat as "select" maybe do nothing.
-            return false;
         case InputKey::Back:
             emit_back_requested();
             return true;
+        case InputKey::Press:
         case InputKey::Up:
         case InputKey::Down:
-            // Could be used to navigate between chips vertically (future)
             return false;
-
     }
     return false;
 }
@@ -217,47 +206,51 @@ void SeedWordsScreen::update_page() {
         lv_obj_del(chip);
     }
     word_chips_.clear();
-    
-    // Update page label
+
+    // Update page indicator
     if (page_label_) {
-        lv_label_set_text_fmt(page_label_, "Page %d/%d", current_page_ + 1, total_pages_);
+        lv_label_set_text_fmt(page_label_, "%d / %d", current_page_ + 1, total_pages_);
     }
-    
-    // Calculate start and end indices
+
+    // Calculate word range for this page
     int start = current_page_ * params_.words_per_page;
     int end = std::min(start + params_.words_per_page, static_cast<int>(params_.words.size()));
-    
-    // Create chips for words on this page
+
+    int cw = chip_width_px();
+
     for (int i = start; i < end; ++i) {
-        create_word_chip(words_container_, i, params_.words[i]);
+        create_word_chip(words_container_, i, params_.words[i], cw);
     }
 }
 
-void SeedWordsScreen::create_word_chip(lv_obj_t* parent, int index, const std::string& word) {
-    lv_obj_t* chip = lv_btn_create(parent);
-    lv_obj_set_size(chip, chip_width(), kChipHeight);
+void SeedWordsScreen::create_word_chip(lv_obj_t* parent, int index, const std::string& word, int width) {
+    lv_obj_t* chip = lv_obj_create(parent);
+    lv_obj_set_size(chip, width, kChipH);
     lv_obj_add_style(chip, &chip_style_, 0);
-    apply_warning_styling(chip); // Add warning styling
-    
-    // Add click event for word selection
-    lv_obj_add_event_cb(chip, [](lv_event_t* e) {
-        auto* screen = static_cast<SeedWordsScreen*>(lv_event_get_user_data(e));
-        if (screen != nullptr) {
-            // Extract index from user_data stored in chip? For simplicity, we'll pass index via event user_data.
-            // We'll need to store index in chip's user_data. For now, we'll skip.
-        }
-    }, LV_EVENT_CLICKED, this);
-    
-    // Create label: index + word
-    lv_obj_t* label = lv_label_create(chip);
-    lv_label_set_text_fmt(label, "%d. %s", index + 1, word.c_str());
-    lv_obj_center(label);
-    
+    lv_obj_clear_flag(chip, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_flex_flow(chip, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(chip, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_all(chip, 4, 0);
+
+    // Word number (dimmed, fixed width)
+    lv_obj_t* num = lv_label_create(chip);
+    char num_buf[8];
+    std::snprintf(num_buf, sizeof(num_buf), "%2d.", index + 1);
+    lv_label_set_text(num, num_buf);
+    lv_obj_set_style_text_color(num, theme::active_theme().TEXT_SECONDARY, 0);
+    lv_obj_set_style_text_font(num, theme::typography::CAPTION, 0);
+    lv_obj_set_width(num, 28);
+
+    // Word text
+    lv_obj_t* lbl = lv_label_create(chip);
+    lv_label_set_text(lbl, word.c_str());
+    lv_obj_set_style_text_font(lbl, theme::typography::BODY, 0);
+    lv_obj_set_flex_grow(lbl, 1);
+
     word_chips_.push_back(chip);
 }
 
 void SeedWordsScreen::apply_warning_styling(lv_obj_t* obj) {
-    // Apply warning chip style (orange/red edges)
     lv_obj_add_style(obj, &warning_chip_style_, 0);
 }
 


### PR DESCRIPTION
## Changes

Implements #97 — SeedWordsScreen visual parity with SeedSigner.

### 2-column word chip grid
- Each chip: dimmed number prefix + word text
- Chip width calculated from profile (screen width - padding - gap) / 2
- Compact row height (28px), tight gap (4px)

### Paged display
- Profile-aware `words_per_page` (6 for 240×240, 8 for 240×320)
- Left/Right key navigation between pages
- Page indicator: `1 / 4` format
- Nav hint at bottom for multi-page seeds

### Warning banner
- Yellow warning text above the word grid
- Default: "Do not digitize these words. Write them down and store offline."
- Customizable via route args

### Styling
- Dark surface chips with subtle border
- Text hierarchy: number in caption/secondary, word in body/primary
- Consistent with SeedSigner theme palette

Closes #97

Co-authored-by: alvroble <50918598+alvroble@users.noreply.github.com>